### PR TITLE
[Refactor] Factory 라이브러리 도입 및 DI Container 구성

### DIFF
--- a/Rephoto_iOS.xcodeproj/project.pbxproj
+++ b/Rephoto_iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0B58CB872E269EA00074972F /* NukeExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 0B58CB862E269EA00074972F /* NukeExtensions */; };
 		0B58CB892E269EA00074972F /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0B58CB882E269EA00074972F /* NukeUI */; };
 		0B58CB8B2E269EA00074972F /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = 0B58CB8A2E269EA00074972F /* NukeVideo */; };
+		0B5E8A0C2FA1F3CB00D38A9C /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = 0BAA00022FB0A00000000001 /* Factory */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,7 +26,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0B68FCF22FA12B44006ADAC4 /* Rephoto_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = Rephoto_iOS.xctestplan; sourceTree = "<group>"; };
+		0B68FCF22FA12B44006ADAC4 /* Rephoto_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Rephoto_iOS.xctestplan; sourceTree = "<group>"; };
 		0B88F6202FA0E1E0001E9851 /* Rephoto_iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Rephoto_iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BE71D522E1657D500E85407 /* Rephoto_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rephoto_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -68,6 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0B5E8A0C2FA1F3CB00D38A9C /* Factory in Frameworks */,
 				0B58CB892E269EA00074972F /* NukeUI in Frameworks */,
 				0B58CB852E269EA00074972F /* Nuke in Frameworks */,
 				0B58CB8B2E269EA00074972F /* NukeVideo in Frameworks */,
@@ -146,6 +148,7 @@
 				0B58CB882E269EA00074972F /* NukeUI */,
 				0B58CB8A2E269EA00074972F /* NukeVideo */,
 				0B4B8A952E40A67100CCBE45 /* Moya */,
+				0BAA00022FB0A00000000001 /* Factory */,
 			);
 			productName = Rephoto_iOS;
 			productReference = 0BE71D522E1657D500E85407 /* Rephoto_iOS.app */;
@@ -182,6 +185,7 @@
 			packageReferences = (
 				0B58CB832E269EA00074972F /* XCRemoteSwiftPackageReference "Nuke" */,
 				0B4B8A942E40A67100CCBE45 /* XCRemoteSwiftPackageReference "Moya" */,
+				0BAA00012FB0A00000000001 /* XCRemoteSwiftPackageReference "Factory" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0BE71D532E1657D500E85407 /* Products */;
@@ -443,7 +447,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
@@ -482,7 +486,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
@@ -539,6 +543,14 @@
 				minimumVersion = 12.8.0;
 			};
 		};
+		0BAA00012FB0A00000000001 /* XCRemoteSwiftPackageReference "Factory" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/hmlongco/Factory";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.3;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -566,6 +578,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0B58CB832E269EA00074972F /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = NukeVideo;
+		};
+		0BAA00022FB0A00000000001 /* Factory */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BAA00012FB0A00000000001 /* XCRemoteSwiftPackageReference "Factory" */;
+			productName = Factory;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Rephoto_iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rephoto_iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "87c6f103f670e9800ab6661dcb42b9ca6ed36e1fe21bf34661e62e3c5891174f",
+  "originHash" : "b99c1bd027481740f8679744827c67cf368f5160c9b1be602635613ace3761bc",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
         "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "factory",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hmlongco/Factory",
+      "state" : {
+        "revision" : "ccc898f21992ebc130bc04cc197460a5ae230bcf",
+        "version" : "2.5.3"
       }
     },
     {

--- a/Rephoto_iOS/Core/DIContainer/AppContainer.swift
+++ b/Rephoto_iOS/Core/DIContainer/AppContainer.swift
@@ -1,0 +1,80 @@
+//
+//  AppContainer.swift
+//  Rephoto_iOS
+//
+//  Created by 김도연 on 4/29/26.
+//
+
+import Factory
+import Moya
+
+extension Container: @retroactive AutoRegistering {
+
+    // MARK: - Token
+
+    private var tokenStore: Factory<TokenStore> {
+        self { TokenStore.shared }.singleton
+    }
+
+    // MARK: - Auth
+
+    private var authPlugin: Factory<AuthPlugin> {
+        self {
+            let store = self.tokenStore.resolve()
+            return AuthPlugin(tokenStore: store)
+        }
+    }
+
+    var authedProvider: Factory<AuthedProvider> {
+        self {
+            let store = self.tokenStore.resolve()
+            return AuthedProvider(tokenStore: store)
+        }.singleton
+    }
+
+    // MARK: - Providers
+
+    var photosProvider: Factory<MoyaProvider<PhotosAPITarget>> {
+        self {
+            MoyaProvider<PhotosAPITarget>(plugins: [self.authPlugin.resolve()])
+        }.singleton
+    }
+
+    var searchProvider: Factory<MoyaProvider<SearchAPITarget>> {
+        self {
+            MoyaProvider<SearchAPITarget>(plugins: [self.authPlugin.resolve()])
+        }.singleton
+    }
+
+    var albumProvider: Factory<MoyaProvider<AlbumAPITarget>> {
+        self {
+            MoyaProvider<AlbumAPITarget>(plugins: [self.authPlugin.resolve()])
+        }.singleton
+    }
+
+    var tagProvider: Factory<MoyaProvider<TagAPITarget>> {
+        self {
+            MoyaProvider<TagAPITarget>(plugins: [self.authPlugin.resolve()])
+        }.singleton
+    }
+
+    var descriptionProvider: Factory<MoyaProvider<DescriptionAPITarget>> {
+        self {
+            MoyaProvider<DescriptionAPITarget>(plugins: [self.authPlugin.resolve()])
+        }.singleton
+    }
+
+    /// 인증 불필요한 요청용 (로그인 등)
+    var plainUserProvider: Factory<MoyaProvider<UserAPITarget>> {
+        self { MoyaProvider<UserAPITarget>() }.singleton
+    }
+
+    // MARK: - AutoRegistering
+
+    public func autoRegister() {
+        authedProvider.register {
+            let store = self.tokenStore.resolve()
+            return AuthedProvider(tokenStore: store)
+        }
+    }
+}

--- a/Rephoto_iOS/Features/Home/ViewModels/HomeViewModel.swift
+++ b/Rephoto_iOS/Features/Home/ViewModels/HomeViewModel.swift
@@ -11,15 +11,17 @@ import Moya
 import PhotosUI
 import Photos
 import UIKit
+import Factory
 
 @Observable
 class HomeViewModel {
     var images: [HomeModel] = []
     var imageUrl: String = ""
-    
+
     var isWarningsCount: Int { images.count(where: { $0.isSensitive }) }
-    
-    private let provider = MoyaProvider<PhotosAPITarget>()
+
+    @ObservationIgnored
+    @Injected(\.photosProvider) private var provider
     
     init() {
         fetchPhotos()

--- a/Rephoto_iOS/Features/Home/ViewModels/PhotoInfoViewModel.swift
+++ b/Rephoto_iOS/Features/Home/ViewModels/PhotoInfoViewModel.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 import Moya
 import Observation
+import Factory
 
 @Observable
 class PhotoInfoViewModel {
-    private let photoProvider = MoyaProvider<PhotosAPITarget>()
-    private let provider = MoyaProvider<TagAPITarget>()
-    private let descriptionProvider = MoyaProvider<DescriptionAPITarget>()
+    @ObservationIgnored
+    @Injected(\.photosProvider) private var photoProvider
+    @ObservationIgnored
+    @Injected(\.tagProvider) private var provider
+    @ObservationIgnored
+    @Injected(\.descriptionProvider) private var descriptionProvider
     
     var isDeleted: Bool = false
     var tags: [TagResponseDto] = []   // ✅ PhotoInfoView 전용 태그 리스트

--- a/Rephoto_iOS/Features/Search/ViewModels/AlbumViewModel.swift
+++ b/Rephoto_iOS/Features/Search/ViewModels/AlbumViewModel.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 import Moya
 import Observation
+import Factory
 
 @Observable
 class AlbumViewModel {
-    private let provider = MoyaProvider<AlbumAPITarget>()
+    @ObservationIgnored
+    @Injected(\.albumProvider) private var provider
 
     var albums: [AlbumResponseDto] = []
     var albumInfo: [[HomeModel]] = []   // ← 빈 배열로 시작

--- a/Rephoto_iOS/Features/Search/ViewModels/SearchViewModel.swift
+++ b/Rephoto_iOS/Features/Search/ViewModels/SearchViewModel.swift
@@ -9,21 +9,22 @@
 import Foundation
 import Combine
 import Moya
+import Factory
 
 @MainActor
 final class SearchViewModel: ObservableObject {
     // MARK: - Input
     @Published var query: String = ""
-    
+
     // MARK: - Output
     @Published var items: [CategoryItem] = []
     @Published var searchResults: [SearchResults] = []
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
-    
+
     // MARK: - Private
     private var cancellables = Set<AnyCancellable>()
-    private let provider = MoyaProvider<SearchAPITarget>()
+    @Injected(\.searchProvider) private var provider
     
     /// 현재 in-flight Moya 요청 토큰
     private var currentRequest: Moya.Cancellable?

--- a/Rephoto_iOS/Features/User/ViewModel/LoginViewModel.swift
+++ b/Rephoto_iOS/Features/User/ViewModel/LoginViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Combine
 import Moya
+import Factory
 
 final class LoginViewModel: ObservableObject {
     @Published var loginId: String = ""
@@ -19,9 +20,9 @@ final class LoginViewModel: ObservableObject {
     @State var name: String = "리포토"
 
     /// 로그인(무인증) 전용
-    private let plainProvider = MoyaProvider<UserAPITarget>()
+    @Injected(\.plainUserProvider) private var plainProvider
     /// 인증요청(만료 시 자동 리프레시 & 재시도)
-    private let authedProvider = AuthedProvider()
+    @Injected(\.authedProvider) private var authedProvider
 
     init() {
         // 앱 시작 시 토큰이 남아있다면 로그인 유지


### PR DESCRIPTION
## Summary
- Factory 라이브러리(v2.5.3) SPM 추가 및 `AppContainer` 구성
- 모든 ViewModel의 `MoyaProvider` 직접 생성을 `@Injected`를 통한 DI 주입으로 전환
- `SWIFT_DEFAULT_ACTOR_ISOLATION`을 `nonisolated`로 변경

## 변경 파일
- **AppContainer.swift** (신규) — Container 확장, Provider/Auth 의존성 등록
- **HomeViewModel / PhotoInfoViewModel / SearchViewModel / AlbumViewModel / LoginViewModel** — `@Injected` 전환
- **project.pbxproj / Package.resolved** — Factory SPM 추가, 빌드 설정 변경

## Test plan
- [x] `xcodebuild build` 성공 확인
- [ ] 로그인 → 사진 목록 조회 → 업로드 플로우 동작 확인
- [ ] 테스트 시 `Container.shared.reset()` 후 mock 주입 확인

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 의존성 주입 프레임워크 추가로 내부 아키텍처 현대화
  * 네트워크 제공자 관리 개선으로 코드 구조 최적화
  * 빌드 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->