### PR TITLE
[Fix] CI SPM 캐시 경로 수정 및 actions 업데이트

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create Config.xcconfig placeholder
         run: |
@@ -25,7 +25,7 @@ jobs:
       - name: Cache SPM dependencies
         uses: actions/cache@v4
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/SourcePackages
+          path: .spm-cache
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
@@ -36,4 +36,5 @@ jobs:
             -scheme Rephoto_iOS \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -configuration Debug \
+            -clonedSourcePackagesDirPath .spm-cache \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -23,7 +23,7 @@ jobs:
           echo 'BASE_URL = https:/$()/placeholder.com' > Rephoto_iOS/Resource/Config.xcconfig
 
       - name: Cache SPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .spm-cache
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 빌드 부분 혹은 패키지 매니저 수정


## 🛠️ 작업내용
- `actions/checkout` v4 → v5 업데이트
- SPM 캐시 경로를 `.spm-cache`로 통일 (캐시 저장 경로와 xcodebuild 참조 경로 불일치 해결)
- xcodebuild에 `-clonedSourcePackagesDirPath .spm-cache` 추가하여 캐시 경로 고정

Closes #24

## 📋 추후 진행 상황
- CI 워크플로우 정상 동작 확인

## 📌 리뷰 포인트
- 캐시 경로 `.spm-cache`가 저장/복원/빌드 모두에서 일관되게 사용되는지 확인

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?