### PR TITLE
[Refactor] 사진 업로드 병렬화 및 테스트 인프라 정비

### DIFF
--- a/Rephoto_iOS/Features/Home/Data/Repositories/PhotoRepository.swift
+++ b/Rephoto_iOS/Features/Home/Data/Repositories/PhotoRepository.swift
@@ -28,23 +28,33 @@ final class PhotoRepository: PhotoRepositoryProtocol {
     }
 
     func uploadPhotos(items: [PhotoUploadItem]) async throws {
-        var uploaded: [PhotoMetadataDTO] = []
+        guard !items.isEmpty else { return }
 
-        for item in items {
-            guard let fileData = try? Data(contentsOf: URL(string: item.imageUrl)!) else { continue }
-            let response = try await adapter.request(PhotosAPITarget.s3Upload(file: fileData))
-            let dto = try decoder.decode(S3UploadResponseDTO.self, from: response.data)
-            let meta = PhotoMetadataDTO(
-                latitude: item.latitude,
-                longitude: item.longitude,
-                imageUrl: dto.imageUrl,
-                createdAt: item.createdAt,
-                fileName: item.fileName
-            )
-            uploaded.append(meta)
+        let adapter = self.adapter
+
+        let uploaded = try await withThrowingTaskGroup(of: PhotoMetadataDTO.self) { group in
+            for item in items {
+                group.addTask {
+                    let fileData = try Data(contentsOf: item.imageUrl)
+                    let response = try await adapter.request(PhotosAPITarget.s3Upload(file: fileData))
+                    let dto = try JSONDecoder().decode(S3UploadResponseDTO.self, from: response.data)
+                    return PhotoMetadataDTO(
+                        latitude: item.latitude,
+                        longitude: item.longitude,
+                        imageUrl: dto.imageUrl,
+                        createdAt: item.createdAt,
+                        fileName: item.fileName
+                    )
+                }
+            }
+
+            var results: [PhotoMetadataDTO] = []
+            for try await dto in group {
+                results.append(dto)
+            }
+            return results
         }
 
-        guard !uploaded.isEmpty else { return }
         let request = PhotoBatchRequestDTO(photos: uploaded)
         _ = try await adapter.request(PhotosAPITarget.savePhotosBatch(request: request))
     }

--- a/Rephoto_iOS/Features/Home/Domain/Models/PhotoUploadItem.swift
+++ b/Rephoto_iOS/Features/Home/Domain/Models/PhotoUploadItem.swift
@@ -10,7 +10,7 @@ import Foundation
 struct PhotoUploadItem: Sendable, Equatable {
     let latitude: Double
     let longitude: Double
-    let imageUrl: String
+    let imageUrl: URL
     let createdAt: String
     let fileName: String
 }

--- a/Rephoto_iOS/Features/Home/Domain/Services/PhotoMetadataExtractor.swift
+++ b/Rephoto_iOS/Features/Home/Domain/Services/PhotoMetadataExtractor.swift
@@ -31,15 +31,19 @@ struct PhotoMetadataExtractor {
         // 파일 이름
         let fileName = item.itemIdentifier ?? UUID().uuidString
 
-        // 임시 파일 저장
+        // 임시 파일 저장 (실패 시 업로드 불가하므로 nil 반환)
         let destURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(fileName).jpg")
-        try? data.write(to: destURL)
+        do {
+            try data.write(to: destURL)
+        } catch {
+            return nil
+        }
 
         return PhotoUploadItem(
             latitude: latitude,
             longitude: longitude,
-            imageUrl: destURL.absoluteString,
+            imageUrl: destURL,
             createdAt: DateFormatter.serverISO.string(from: createdAt),
             fileName: destURL.lastPathComponent
         )

--- a/Rephoto_iOSTests/DecodingPerformanceTests.swift
+++ b/Rephoto_iOSTests/DecodingPerformanceTests.swift
@@ -52,13 +52,13 @@ final class DecodingPerformanceTests: XCTestCase {
     /// 검색 결과 50개 디코딩 성능
     func test_decodeSearchResponse_50() throws {
         let data = MockDataFactory.searchResponseJSON(resultCount: 50)
-        measureDecode(SearchResponseDto.self, from: data)
+        measureDecode(SearchResponseDTO.self, from: data)
     }
 
     /// 검색 결과 200개 디코딩 성능
     func test_decodeSearchResponse_200() throws {
         let data = MockDataFactory.searchResponseJSON(resultCount: 200)
-        measureDecode(SearchResponseDto.self, from: data)
+        measureDecode(SearchResponseDTO.self, from: data)
     }
 
     // MARK: - AlbumResponseDto 디코딩
@@ -66,6 +66,6 @@ final class DecodingPerformanceTests: XCTestCase {
     /// 앨범 리스트 20개 디코딩 성능
     func test_decodeAlbumList_20() throws {
         let data = MockDataFactory.albumListJSON(count: 20)
-        measureDecode([AlbumResponseDto].self, from: data)
+        measureDecode([AlbumResponseDTO].self, from: data)
     }
 }

--- a/Rephoto_iOSTests/MemoryPerformanceTests.swift
+++ b/Rephoto_iOSTests/MemoryPerformanceTests.swift
@@ -12,7 +12,7 @@ final class MemoryPerformanceTests: XCTestCase {
 
     // measure 블록 종료 후에도 객체를 retain하여 메모리 delta 측정
     private var retainedModels: [Photo] = []
-    private var retainedSearchResult: SearchResponseDto?
+    private var retainedSearchResult: SearchResponseDTO?
     private var retainedDtos: [PhotoResponseDTO] = []
 
     override func tearDown() {
@@ -35,7 +35,7 @@ final class MemoryPerformanceTests: XCTestCase {
     func test_memoryFootprint_searchResults_500() {
         let data = MockDataFactory.searchResponseJSON(resultCount: 500)
         measure(metrics: [XCTMemoryMetric()]) {
-            retainedSearchResult = try? JSONDecoder().decode(SearchResponseDto.self, from: data)
+            retainedSearchResult = try? JSONDecoder().decode(SearchResponseDTO.self, from: data)
             XCTAssertEqual(retainedSearchResult?.searchResults.count, 500)
         }
     }

--- a/Rephoto_iOSTests/MemoryPerformanceTests.swift
+++ b/Rephoto_iOSTests/MemoryPerformanceTests.swift
@@ -35,8 +35,12 @@ final class MemoryPerformanceTests: XCTestCase {
     func test_memoryFootprint_searchResults_500() {
         let data = MockDataFactory.searchResponseJSON(resultCount: 500)
         measure(metrics: [XCTMemoryMetric()]) {
-            retainedSearchResult = try? JSONDecoder().decode(SearchResponseDTO.self, from: data)
-            XCTAssertEqual(retainedSearchResult?.searchResults.count, 500)
+            do {
+                retainedSearchResult = try JSONDecoder().decode(SearchResponseDTO.self, from: data)
+                XCTAssertEqual(retainedSearchResult?.searchResults.count, 500)
+            } catch {
+                XCTFail("Decode failed: \(error)")
+            }
         }
     }
 

--- a/Rephoto_iOSTests/MockDataFactory.swift
+++ b/Rephoto_iOSTests/MockDataFactory.swift
@@ -19,10 +19,10 @@ enum MockDataFactory {
             "imageUrl": "https://example.com/photos/photo_\(id).jpg",
             "latitude": 37.5665 + (Double((id % 11) - 5) * 0.01),
             "longitude": 126.9780 + (Double((id % 11) - 5) * 0.01),
-            "createdAt": "2025-07-\(String(format: "%02d", (id % 28) + 1))T12:00:00",
+            "createdAt": "2025-07-\(String(format: "%02d", (id % 28) + 1))T12:00:00Z",
             "fileName": "IMG_\(id).jpg",
             "tags": ["풍경", "서울", "여행"],
-            "private": id % 5 == 0
+            "isSensitive": id % 5 == 0
         ]
     }
 

--- a/Rephoto_iOSTests/PhotoInfoPerformanceTests.swift
+++ b/Rephoto_iOSTests/PhotoInfoPerformanceTests.swift
@@ -26,7 +26,7 @@ final class PhotoInfoPerformanceTests: XCTestCase {
     }
 
     private func makeTagRequestJSON(tagName: String) -> Data {
-        let request = TagRequestDTO(tagName: tagName)
+        let request = UpdateTagRequestDTO(tagName: tagName)
         return try! JSONEncoder().encode(request)
     }
 
@@ -55,7 +55,7 @@ final class PhotoInfoPerformanceTests: XCTestCase {
         measure(metrics: [XCTClockMetric()]) {
             let encoder = JSONEncoder()
             for i in 0..<1000 {
-                let request = TagRequestDTO(tagName: "새태그_\(i)")
+                let request = UpdateTagRequestDTO(tagName: "새태그_\(i)")
                 _ = try! encoder.encode(request)
             }
         }

--- a/Rephoto_iOSTests/PhotoRepositoryTests.swift
+++ b/Rephoto_iOSTests/PhotoRepositoryTests.swift
@@ -1,0 +1,141 @@
+//
+//  PhotoRepositoryTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 6/6/26.
+//
+
+import XCTest
+@testable import Rephoto_iOS
+
+final class PhotoRepositoryTests: XCTestCase {
+
+    private var tempFiles: [URL] = []
+
+    override func tearDown() async throws {
+        for url in tempFiles { try? FileManager.default.removeItem(at: url) }
+        tempFiles = []
+        StubURLProtocol.reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> PhotoRepository {
+        let session = StubURLProtocol.session()
+        let baseURL = URL(string: "https://api.test")!
+        let networkClient = NetworkClient(
+            session: session,
+            tokenStore: MockTokenStore(),
+            refreshService: MockTokenRefreshService()
+        )
+        let adapter = MoyaNetworkAdapter(networkClient: networkClient, baseURL: baseURL)
+        return PhotoRepository(adapter: adapter)
+    }
+
+    private func makeUploadItem(id: Int) throws -> PhotoUploadItem {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_upload_\(id)_\(UUID().uuidString).jpg")
+        try Data("fake image data \(id)".utf8).write(to: url)
+        tempFiles.append(url)
+        return PhotoUploadItem(
+            latitude: 37.5,
+            longitude: 126.9,
+            imageUrl: url,
+            createdAt: "2026-06-06T12:00:00",
+            fileName: url.lastPathComponent
+        )
+    }
+
+    private static func okResponse(for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func errorResponse(for request: URLRequest, code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: request.url!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    // MARK: - Tests
+
+    /// 빈 배열은 어떤 네트워크 요청도 발생시키지 않고 즉시 반환한다.
+    func test_uploadPhotos_emptyItems_makesNoRequests() async throws {
+        let sut = makeSUT()
+        StubURLProtocol.handler = { _ in
+            XCTFail("Empty items must not trigger any request")
+            throw URLError(.unknown)
+        }
+
+        try await sut.uploadPhotos(items: [])
+
+        XCTAssertEqual(StubURLProtocol.recordedRequests.count, 0)
+    }
+
+    /// 모든 item이 성공하면 각 item당 S3 1회 + batch save 1회 호출된다.
+    func test_uploadPhotos_allSuccess_uploadsEachItemThenCallsBatchSave() async throws {
+        let sut = makeSUT()
+        let items = try (0..<3).map { try makeUploadItem(id: $0) }
+
+        StubURLProtocol.handler = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/photos/s3") {
+                let body = #"{"imageUrl":"https://s3.test/uploaded.jpg"}"#
+                return (Self.okResponse(for: request), Data(body.utf8))
+            } else if path.hasSuffix("/photos/batch") {
+                return (Self.okResponse(for: request), Data("{}".utf8))
+            } else {
+                XCTFail("Unexpected path: \(path)")
+                throw URLError(.badURL)
+            }
+        }
+
+        try await sut.uploadPhotos(items: items)
+
+        let recorded = StubURLProtocol.recordedRequests
+        let s3Calls = recorded.filter { $0.url?.path.hasSuffix("/photos/s3") == true }
+        let batchCalls = recorded.filter { $0.url?.path.hasSuffix("/photos/batch") == true }
+        XCTAssertEqual(s3Calls.count, 3, "S3 upload should be called once per item")
+        XCTAssertEqual(batchCalls.count, 1, "Batch save should be called exactly once")
+    }
+
+    /// S3 업로드 중 한 건이라도 실패하면 throw하고 batch save는 호출되지 않는다.
+    func test_uploadPhotos_anyS3Failure_throwsAndSkipsBatchSave() async throws {
+        let sut = makeSUT()
+        let items = try (0..<3).map { try makeUploadItem(id: $0) }
+
+        let lock = NSLock()
+        nonisolated(unsafe) var failureEmitted = false
+
+        StubURLProtocol.handler = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/photos/batch") {
+                XCTFail("Batch save must not run when any S3 upload fails")
+                throw URLError(.unknown)
+            }
+            // 첫 S3 요청만 500을 반환해 한 건 실패를 보장한다.
+            let shouldFail: Bool = lock.withLock {
+                if !failureEmitted {
+                    failureEmitted = true
+                    return true
+                }
+                return false
+            }
+            if shouldFail {
+                return (Self.errorResponse(for: request, code: 500), Data("server error".utf8))
+            }
+            let body = #"{"imageUrl":"https://s3.test/uploaded.jpg"}"#
+            return (Self.okResponse(for: request), Data(body.utf8))
+        }
+
+        do {
+            try await sut.uploadPhotos(items: items)
+            XCTFail("Expected uploadPhotos to throw")
+        } catch {
+            // 성공: 에러가 정상 전파됨
+        }
+
+        let batchCalls = StubURLProtocol.recordedRequests.filter {
+            $0.url?.path.hasSuffix("/photos/batch") == true
+        }
+        XCTAssertEqual(batchCalls.count, 0)
+    }
+}

--- a/Rephoto_iOSTests/TestHelpers.swift
+++ b/Rephoto_iOSTests/TestHelpers.swift
@@ -1,0 +1,105 @@
+//
+//  TestHelpers.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 6/6/26.
+//
+
+import Foundation
+@testable import Rephoto_iOS
+
+// MARK: - StubURLProtocol
+
+/// URLSession의 모든 요청을 가로채 핸들러로 응답을 반환하는 stub.
+///
+/// 사용법:
+///   StubURLProtocol.handler = { request in ... }
+///   let session = StubURLProtocol.session()
+final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+
+    typealias Handler = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _handler: Handler?
+    nonisolated(unsafe) private static var _recordedRequests: [URLRequest] = []
+
+    static var handler: Handler? {
+        get { lock.withLock { _handler } }
+        set { lock.withLock { _handler = newValue } }
+    }
+
+    static var recordedRequests: [URLRequest] {
+        lock.withLock { _recordedRequests }
+    }
+
+    static func reset() {
+        lock.withLock {
+            _handler = nil
+            _recordedRequests = []
+        }
+    }
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    // MARK: URLProtocol
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.withLock { Self._recordedRequests.append(request) }
+
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - MockTokenStore
+
+final actor MockTokenStore: TokenStore {
+    private var access: String?
+    private var refresh: String?
+
+    init(accessToken: String? = "test-access", refreshToken: String? = "test-refresh") {
+        self.access = accessToken
+        self.refresh = refreshToken
+    }
+
+    func getAccessToken() async -> String? { access }
+    func getRefreshToken() async -> String? { refresh }
+
+    func save(accessToken: String, refreshToken: String) async throws {
+        access = accessToken
+        refresh = refreshToken
+    }
+
+    func clear() async throws {
+        access = nil
+        refresh = nil
+    }
+}
+
+// MARK: - MockTokenRefreshService
+
+struct MockTokenRefreshService: TokenRefreshService {
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        throw URLError(.userAuthenticationRequired)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

### 업로드 경로 개선
- `PhotoRepository.uploadPhotos`를 순차 `for` 루프에서 `withThrowingTaskGroup`으로 변경하여 S3 업로드 병렬화
- `URL(string: item.imageUrl)!` 강제 언래핑 제거 — `PhotoUploadItem.imageUrl` 타입을 `String`에서 `URL`로 변경하여 타입 시스템 차원에서 보장
- `try? Data(contentsOf:)` silent skip 제거 — 한 건이라도 실패하면 TaskGroup이 자동 cancel 후 throw, 사용자에게 정상적으로 노출됨
- `PhotoMetadataExtractor`의 임시 파일 쓰기 실패를 `try?` → 명시적 `do/catch + return nil`로 처리

### 테스트 추가
- `PhotoRepositoryTests` — 3개 케이스
  - `test_uploadPhotos_emptyItems_makesNoRequests`
  - `test_uploadPhotos_allSuccess_uploadsEachItemThenCallsBatchSave`
  - `test_uploadPhotos_anyS3Failure_throwsAndSkipsBatchSave`
- `TestHelpers` — 재사용 가능한 인프라
  - `StubURLProtocol` — `URLSession` 응답 stub + 요청 기록
  - `MockTokenStore` — 메모리 기반 `TokenStore` actor
  - `MockTokenRefreshService`

### 기존 테스트 빌드 복구
- `PhotoInfoPerformanceTests` — 존재하지 않는 `TagRequestDTO` → `UpdateTagRequestDTO`
- `DecodingPerformanceTests` — album 테스트의 `[SearchResponseDTO]` → `[AlbumResponseDTO]`
- `MemoryPerformanceTests` — `SearchResponseDto` → `SearchResponseDTO`
- `MockDataFactory` — 옛 필드명 `private` → `isSensitive`, `createdAt`에 ISO8601 타임존(`Z`) 추가

## 📋 추후 진행 상황

- 죽은 코드 정리 (ContentView DEBUG 바이패스, Settings/Trash/Help placeholder, UserAPITarget 미사용 case)
- 에러 타입 통합 (NetworkError / RepositoryError 매핑 일원화)
- 모듈 분리 및 의존성 단방향 강제

## 📌 리뷰 포인트

- `PhotoRepository.uploadPhotos`의 TaskGroup 내부에서 `self.adapter`를 로컬로 캡처한 부분, 그리고 `JSONDecoder()`를 각 task 내에서 새로 만든 점이 의도된 선택인지 확인 부탁드립니다 (Sendable 안전성 우선)
- `PhotoUploadItem.imageUrl` 타입 변경의 파급은 `PhotoMetadataExtractor`와 `PhotoRepository` 두 호출처에 한정됩니다
- `StubURLProtocol`은 다른 Repository 테스트에서도 그대로 재사용 가능하도록 작성했습니다

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

---

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진 업로드가 동시 업로드 방식으로 전환되어 처리 속도 향상

* **버그 수정**
  * 파일 읽기/검증 실패 시 더 엄격하게 오류를 전파하여 실패 상황을 명확히 처리

* **테스트**
  * 사진 업로드 동작을 검증하는 통합 테스트 추가
  * 테스트용 네트워크 스텁·토큰 목 등 테스트 헬퍼 확대 및 목데이터 포맷 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->