### PR TITLE
[Refactor] 업로드 이미지 다운샘플 + JPEG 압축 (ImageIO)

### DIFF
--- a/Rephoto_iOS/Features/Home/Domain/Services/PhotoMetadataExtractor.swift
+++ b/Rephoto_iOS/Features/Home/Domain/Services/PhotoMetadataExtractor.swift
@@ -31,7 +31,10 @@ struct PhotoMetadataExtractor {
         let longitude = gps?["Longitude"] as? Double ?? 0.0
 
         // 파일 이름
-        let fileName = item.itemIdentifier ?? UUID().uuidString
+        // itemIdentifier는 "UUID/L0/001"처럼 슬래시를 포함할 수 있어, 그대로 쓰면
+        // appendingPathComponent가 하위 경로로 해석해 임시 파일 저장이 실패한다.
+        let rawName = item.itemIdentifier ?? UUID().uuidString
+        let fileName = rawName.replacingOccurrences(of: "/", with: "_")
 
         // 업로드 전 다운샘플 + JPEG 압축 (원본 그대로 올리던 것을 ImageIO로 교체)
         // 위치/촬영시간은 위에서 EXIF로 이미 추출했으므로, 압축본에 메타가 빠져도 무방

--- a/Rephoto_iOS/Features/Home/Domain/Services/PhotoMetadataExtractor.swift
+++ b/Rephoto_iOS/Features/Home/Domain/Services/PhotoMetadataExtractor.swift
@@ -7,6 +7,8 @@
 
 import PhotosUI
 import SwiftUI
+import ImageIO
+import UniformTypeIdentifiers
 
 struct PhotoMetadataExtractor {
     static func extract(from item: PhotosPickerItem) async -> PhotoUploadItem? {
@@ -31,11 +33,26 @@ struct PhotoMetadataExtractor {
         // 파일 이름
         let fileName = item.itemIdentifier ?? UUID().uuidString
 
+        // 업로드 전 다운샘플 + JPEG 압축 (원본 그대로 올리던 것을 ImageIO로 교체)
+        // 위치/촬영시간은 위에서 EXIF로 이미 추출했으므로, 압축본에 메타가 빠져도 무방
+        guard let compressed = downsampledJPEG(from: source, maxPixelSize: 2048, quality: 0.8) else {
+            return nil
+        }
+
+        #if DEBUG
+        let beforeKB = data.count / 1024
+        let afterKB = compressed.count / 1024
+        let pxW = properties[kCGImagePropertyPixelWidth as String] as? Int ?? 0
+        let pxH = properties[kCGImagePropertyPixelHeight as String] as? Int ?? 0
+        let ratio = beforeKB == 0 ? 0 : afterKB * 100 / beforeKB
+        print("📷 [압축] \(pxW)x\(pxH)  \(beforeKB)KB → \(afterKB)KB  (\(ratio)%)")
+        #endif
+
         // 임시 파일 저장 (실패 시 업로드 불가하므로 nil 반환)
         let destURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(fileName).jpg")
         do {
-            try data.write(to: destURL)
+            try compressed.write(to: destURL)
         } catch {
             return nil
         }
@@ -47,5 +64,37 @@ struct PhotoMetadataExtractor {
             createdAt: DateFormatter.serverISO.string(from: createdAt),
             fileName: destURL.lastPathComponent
         )
+    }
+
+    /// ImageIO로 디코드 시점에 다운샘플 → JPEG 인코딩.
+    /// `UIImage(data:).jpegData()`는 풀해상도 비트맵을 메모리에 올려서 4000x3000 기준 ~36MB가 튀지만,
+    /// `CGImageSourceCreateThumbnailAtIndex`는 목표 크기로만 디코드해 피크 메모리를 크게 낮춘다.
+    private static func downsampledJPEG(
+        from source: CGImageSource,
+        maxPixelSize: CGFloat,
+        quality: CGFloat
+    ) -> Data? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true, // EXIF 회전 반영 (세로 사진 눕는 것 방지)
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        let outData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            outData, UTType.jpeg.identifier as CFString, 1, nil
+        ) else {
+            return nil
+        }
+        CGImageDestinationAddImage(
+            destination, cgImage,
+            [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return outData as Data
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

리팩토링 계획 **Step 7(성능 최적화)** 의 "업로드 전 이미지 압축" 항목입니다.

원본 이미지를 그대로 업로드하던 방식을 **ImageIO 기반 다운샘플 + JPEG 압축**으로 교체했습니다.

- `CGImageSourceCreateThumbnailAtIndex`로 **디코드 시점에 다운샘플**(max 2048px) → 풀해상도 비트맵을 메모리에 올리지 않아 피크 메모리 절감 (`UIImage(data:).jpegData()`는 4000x3000 기준 ~36MB 비트맵이 메모리에 튐)
- JPEG 압축(quality 0.8)으로 업로드 용량/대역폭 절감
- `kCGImageSourceCreateThumbnailWithTransform`로 EXIF 회전 반영 → 세로 사진이 눕는 문제 방지
- 위치/촬영시간은 압축 전 EXIF에서 이미 추출하므로 메타데이터 손실 영향 없음
- `#if DEBUG` 압축 전후 용량 로그 추가 (압축률 확인용)

## 📋 추후 진행 상황

- Step 7 잔여: DateFormatter 캐싱, ETag 기반 캐시, 태그 O(1) 조회

## 📌 리뷰 포인트

- 다운샘플 목표 크기(2048px)와 품질(0.8)이 적절한지
- EXIF 회전 반영(`...WithTransform`)이 의도대로 동작하는지

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

Closes #33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 사진 업로드 시 원본 이미지를 그대로 전송하던 방식을, 더 작은 크기의 JPEG로 최적화해 전송하도록 개선했습니다.
  * 위치 정보와 촬영 시간 등 EXIF 메타데이터는 기존과 동일하게 유지됩니다.
* **개선**
  * 일부 임시 파일 경로 해석 오류 가능성을 줄이기 위해 파일명 표기를 안정화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->