### PR TITLE
[Refactor] LoginViewModel에서 세션/인증 상태 분리 (SessionStore 도입)

### DIFF
--- a/Rephoto_iOS/App/ContentView.swift
+++ b/Rephoto_iOS/App/ContentView.swift
@@ -8,20 +8,21 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var loginVM: LoginViewModel
+    @State private var session: SessionStore
 
     init(userProvider: UserUseCaseProviderProtocol) {
-        self._loginVM = State(initialValue: LoginViewModel(provider: userProvider))
+        self._session = State(initialValue: SessionStore(provider: userProvider))
     }
 
     var body: some View {
         Group {
-            if loginVM.isLoggedIn {
+            if session.isLoggedIn {
                 RephotoTabView()
             } else {
-                LoginView(loginVM: loginVM)
+                LoginView(session: session)
             }
         }
+        .task { await session.restore() }
     }
 }
 

--- a/Rephoto_iOS/App/ContentView.swift
+++ b/Rephoto_iOS/App/ContentView.swift
@@ -6,13 +6,10 @@
 //
 
 import SwiftUI
+import Factory
 
 struct ContentView: View {
-    @State private var session: SessionStore
-
-    init(userProvider: UserUseCaseProviderProtocol) {
-        self._session = State(initialValue: SessionStore(provider: userProvider))
-    }
+    @Injected(\.sessionStore) private var session
 
     var body: some View {
         Group {
@@ -28,6 +25,6 @@ struct ContentView: View {
 
 #if DEBUG
 #Preview {
-    ContentView(userProvider: MockUserUseCaseProvider())
+    ContentView()
 }
 #endif

--- a/Rephoto_iOS/App/Rephoto_iOSApp.swift
+++ b/Rephoto_iOS/App/Rephoto_iOSApp.swift
@@ -6,15 +6,12 @@
 //
 
 import SwiftUI
-import Factory
 
 @main
 struct Rephoto_iOSApp: App {
-    @Injected(\.userUseCaseProvider) private var userProvider
-
     var body: some Scene {
         WindowGroup {
-            ContentView(userProvider: userProvider)
+            ContentView()
         }
     }
 }

--- a/Rephoto_iOS/Core/DIContainer/AppContainer.swift
+++ b/Rephoto_iOS/Core/DIContainer/AppContainer.swift
@@ -80,6 +80,17 @@ extension Container: @retroactive AutoRegistering {
         }
     }
 
+    // MARK: - Session
+
+    /// 앱 전역 세션. @MainActor 타입이므로 메인 스레드 해석을 전제로 한다 (SwiftUI 뷰 초기화 시점).
+    var sessionStore: Factory<SessionStore> {
+        self {
+            MainActor.assumeIsolated {
+                SessionStore(provider: self.userUseCaseProvider.resolve())
+            }
+        }.singleton
+    }
+
     // MARK: - AutoRegistering
 
     public func autoRegister() {

--- a/Rephoto_iOS/Features/RephotoTabView.swift
+++ b/Rephoto_iOS/Features/RephotoTabView.swift
@@ -10,6 +10,7 @@ import PhotosUI
 import Factory
 
 struct RephotoTabView: View {
+    @Injected(\.sessionStore) private var session
     @Injected(\.homeUseCaseProvider) private var homeProvider
     @Injected(\.searchUseCaseProvider) private var searchProvider
 
@@ -24,6 +25,8 @@ struct RephotoTabView: View {
         }
         .tint(.green)
         .tabBarMinimizeBehavior(.onScrollDown)
+        // 하위 탭(프로필/로그아웃 UI 등)이 @Environment(SessionStore.self)로 세션에 접근
+        .environment(session)
     }
 }
 

--- a/Rephoto_iOS/Features/User/Presentation/Session/SessionStore.swift
+++ b/Rephoto_iOS/Features/User/Presentation/Session/SessionStore.swift
@@ -1,0 +1,62 @@
+//
+//  SessionStore.swift
+//  Rephoto_iOS
+//
+//  Created by 김도연 on 7/2/26.
+//
+
+import SwiftUI
+
+/// 앱 전역 인증/세션 상태를 소유한다.
+/// 인증 동작(로그인/로그아웃/복원)을 담당하며 실패는 throw로 알린다.
+/// 로딩/에러 같은 화면 표현 상태는 각 화면의 ViewModel이 가진다.
+@Observable
+@MainActor
+final class SessionStore {
+    private let provider: UserUseCaseProviderProtocol
+
+    private(set) var isLoggedIn = false
+    private(set) var userInfo: UserInfo?
+    private(set) var name: String = "리포토"
+
+    init(provider: UserUseCaseProviderProtocol) {
+        self.provider = provider
+
+        provider.setOnRefreshFailed { [weak self] in
+            Task { @MainActor in
+                self?.forceLogout()
+            }
+        }
+    }
+
+    /// 앱 시작 시 저장된 토큰으로 세션 복원 (자동 로그인).
+    func restore() async {
+        guard await provider.hasTokens() else { return }
+        isLoggedIn = true
+        await refreshUser()
+    }
+
+    /// 자격 증명으로 로그인. 실패 시 throw.
+    func login(id: String, password: String) async throws {
+        try await provider.login().execute(loginId: id, password: password)
+        isLoggedIn = true
+        await refreshUser()
+    }
+
+    func logout() async {
+        try? await provider.logout().execute()
+        forceLogout()
+    }
+
+    /// 토큰 리프레시 실패 등으로 인한 강제 로그아웃 (로컬 상태만 정리).
+    func forceLogout() {
+        userInfo = nil
+        isLoggedIn = false
+    }
+
+    private func refreshUser() async {
+        guard let info = try? await provider.fetchUser().execute() else { return }
+        userInfo = info
+        name = info.name
+    }
+}

--- a/Rephoto_iOS/Features/User/Presentation/ViewModels/LoginViewModel.swift
+++ b/Rephoto_iOS/Features/User/Presentation/ViewModels/LoginViewModel.swift
@@ -10,8 +10,8 @@ import SwiftUI
 @Observable
 @MainActor
 final class LoginViewModel {
-    let provider: UserUseCaseProviderProtocol
-    
+    private let session: SessionStore
+
     var loginId: String = ""
     var password: String = ""
     private(set) var isLoading = false
@@ -20,25 +20,9 @@ final class LoginViewModel {
         get { errorMessage != nil }
         set { if !newValue { errorMessage = nil } }
     }
-    private(set) var isLoggedIn = false
-    private(set) var userInfo: UserInfo?
-    private(set) var name: String = "리포토"
 
-    init(provider: UserUseCaseProviderProtocol) {
-        self.provider = provider
-
-        provider.setOnRefreshFailed { [weak self] in
-            Task { @MainActor in
-                self?.forceLogout()
-            }
-        }
-    }
-
-    func onAppear() async {
-        if await provider.hasTokens() {
-            isLoggedIn = true
-            await fetchUser()
-        }
+    init(session: SessionStore) {
+        self.session = session
     }
 
     func login() async {
@@ -51,47 +35,11 @@ final class LoginViewModel {
         errorMessage = nil
 
         do {
-            try await provider.login().execute(loginId: loginId, password: password)
-            isLoggedIn = true
-            await fetchUser()
+            try await session.login(id: loginId, password: password)
         } catch {
             errorMessage = "로그인 실패: \(error.localizedDescription)"
         }
 
         isLoading = false
-    }
-
-    func fetchUser() async {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            let info = try await provider.fetchUser().execute()
-            userInfo = info
-            name = info.name
-        } catch {
-            errorMessage = "내 정보 조회 실패: \(error.localizedDescription)"
-        }
-
-        isLoading = false
-    }
-
-    func logout() async {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            try await provider.logout().execute()
-        } catch {
-            errorMessage = "로그아웃 실패: \(error.localizedDescription)"
-        }
-
-        forceLogout()
-        isLoading = false
-    }
-
-    func forceLogout() {
-        userInfo = nil
-        isLoggedIn = false
     }
 }

--- a/Rephoto_iOS/Features/User/Presentation/Views/LoginView.swift
+++ b/Rephoto_iOS/Features/User/Presentation/Views/LoginView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct LoginView: View {
-    @Bindable var loginVM: LoginViewModel
+    @State private var loginVM: LoginViewModel
+
+    init(session: SessionStore) {
+        self._loginVM = State(initialValue: LoginViewModel(session: session))
+    }
 
     var body: some View {
         ZStack {
@@ -26,7 +30,6 @@ struct LoginView: View {
                 Text(message)
             }
         }
-        .task { await loginVM.onAppear() }
     }
 
     // MARK: - Title
@@ -91,6 +94,6 @@ struct LoginView: View {
 
 #if DEBUG
 #Preview("Login") {
-    LoginView(loginVM: LoginViewModel(provider: MockUserUseCaseProvider()))
+    LoginView(session: SessionStore(provider: MockUserUseCaseProvider()))
 }
 #endif

--- a/Rephoto_iOSTests/LoginViewModelTests.swift
+++ b/Rephoto_iOSTests/LoginViewModelTests.swift
@@ -1,0 +1,77 @@
+//
+//  LoginViewModelTests.swift
+//  Rephoto_iOSTests
+//
+//  로그인 화면 ViewModel의 표현 상태 검증.
+//  - 입력 검증(빈 필드) 시 에러 메시지, 세션 호출 없음
+//  - 로그인 성공/실패 시 isLoading/errorMessage 상태 전이
+//
+
+import XCTest
+@testable import Rephoto_iOS
+
+@MainActor
+final class LoginViewModelTests: XCTestCase {
+
+    private var provider: MockUserUseCaseProvider!
+    private var session: SessionStore!
+    private var sut: LoginViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = MockUserUseCaseProvider()
+        session = SessionStore(provider: provider)
+        sut = LoginViewModel(session: session)
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        session = nil
+        provider = nil
+        try await super.tearDown()
+    }
+
+    func test_login_emptyFields_setsValidationError_withoutCallingSession() async {
+        sut.loginId = ""
+        sut.password = "pw"
+
+        await sut.login()
+
+        XCTAssertEqual(sut.errorMessage, "아이디와 비밀번호를 입력해주세요.")
+        XCTAssertEqual(provider.loginCallCount, 0)
+        XCTAssertFalse(session.isLoggedIn)
+    }
+
+    func test_login_success_logsInWithoutError() async {
+        provider.fetchUserResult = .success(UserInfo(userId: 1, loginId: 100, name: "도연"))
+        sut.loginId = "dodle"
+        sut.password = "pw"
+
+        await sut.login()
+
+        XCTAssertNil(sut.errorMessage)
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertTrue(session.isLoggedIn)
+    }
+
+    func test_login_failure_setsErrorMessage_andEndsLoading() async {
+        provider.loginResult = .failure(MockUserError.loginFailed)
+        sut.loginId = "dodle"
+        sut.password = "pw"
+
+        await sut.login()
+
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertTrue(sut.isShowingError)
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertFalse(session.isLoggedIn)
+    }
+
+    func test_isShowingError_setFalse_clearsErrorMessage() {
+        sut.errorMessage = "에러"
+
+        sut.isShowingError = false
+
+        XCTAssertNil(sut.errorMessage)
+    }
+}

--- a/Rephoto_iOSTests/MockUserUseCaseProvider.swift
+++ b/Rephoto_iOSTests/MockUserUseCaseProvider.swift
@@ -1,0 +1,86 @@
+//
+//  MockUserUseCaseProvider.swift
+//  Rephoto_iOSTests
+//
+//  SessionStore / LoginViewModel 테스트용 mock.
+//  - 각 UseCase의 결과를 Result로 미리 설정
+//  - 호출 횟수/인자를 기록해 상호작용 검증 가능
+//
+
+import Foundation
+@testable import Rephoto_iOS
+
+enum MockUserError: Error {
+    case loginFailed
+    case fetchFailed
+    case logoutFailed
+}
+
+final class MockUserUseCaseProvider: UserUseCaseProviderProtocol {
+
+    // 테스트에서 시나리오별로 설정하는 결과값
+    var hasTokensResult = false
+    var loginResult: Result<Void, Error> = .success(())
+    var fetchUserResult: Result<UserInfo, Error> = .failure(MockUserError.fetchFailed)
+    var logoutResult: Result<Void, Error> = .success(())
+
+    // 호출 기록
+    private(set) var loginCallCount = 0
+    private(set) var lastLoginId: String?
+    private(set) var lastPassword: String?
+    private(set) var fetchUserCallCount = 0
+    private(set) var logoutCallCount = 0
+    private(set) var onRefreshFailed: (@Sendable () -> Void)?
+
+    func hasTokens() async -> Bool {
+        hasTokensResult
+    }
+
+    func setOnRefreshFailed(_ handler: @escaping @Sendable () -> Void) {
+        onRefreshFailed = handler
+    }
+
+    func login() -> LoginUseCaseProtocol {
+        StubLoginUseCase { id, password in
+            self.loginCallCount += 1
+            self.lastLoginId = id
+            self.lastPassword = password
+            try self.loginResult.get()
+        }
+    }
+
+    func fetchUser() -> FetchUserUseCaseProtocol {
+        StubFetchUserUseCase {
+            self.fetchUserCallCount += 1
+            return try self.fetchUserResult.get()
+        }
+    }
+
+    func logout() -> LogoutUseCaseProtocol {
+        StubLogoutUseCase {
+            self.logoutCallCount += 1
+            try self.logoutResult.get()
+        }
+    }
+}
+
+private struct StubLoginUseCase: LoginUseCaseProtocol {
+    let onExecute: (String, String) throws -> Void
+    func execute(loginId: String, password: String) async throws {
+        try onExecute(loginId, password)
+    }
+}
+
+private struct StubFetchUserUseCase: FetchUserUseCaseProtocol {
+    let onExecute: () throws -> UserInfo
+    func execute() async throws -> UserInfo {
+        try onExecute()
+    }
+}
+
+private struct StubLogoutUseCase: LogoutUseCaseProtocol {
+    let onExecute: () throws -> Void
+    func execute() async throws {
+        try onExecute()
+    }
+}

--- a/Rephoto_iOSTests/SessionStoreTests.swift
+++ b/Rephoto_iOSTests/SessionStoreTests.swift
@@ -1,0 +1,133 @@
+//
+//  SessionStoreTests.swift
+//  Rephoto_iOSTests
+//
+//  앱 전역 세션 상태(SessionStore)의 동작 검증.
+//  - restore: 토큰 유무에 따른 자동 로그인
+//  - login/logout: 성공/실패 시 상태 전이
+//  - 토큰 리프레시 실패 콜백 → 강제 로그아웃
+//
+
+import XCTest
+@testable import Rephoto_iOS
+
+@MainActor
+final class SessionStoreTests: XCTestCase {
+
+    private var provider: MockUserUseCaseProvider!
+    private var sut: SessionStore!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = MockUserUseCaseProvider()
+        sut = SessionStore(provider: provider)
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        provider = nil
+        try await super.tearDown()
+    }
+
+    private let stubUser = UserInfo(userId: 1, loginId: 100, name: "도연")
+
+    // MARK: - restore
+
+    func test_restore_withoutTokens_staysLoggedOut() async {
+        provider.hasTokensResult = false
+
+        await sut.restore()
+
+        XCTAssertFalse(sut.isLoggedIn)
+        XCTAssertNil(sut.userInfo)
+        XCTAssertEqual(provider.fetchUserCallCount, 0)
+    }
+
+    func test_restore_withTokens_logsInAndFetchesUser() async {
+        provider.hasTokensResult = true
+        provider.fetchUserResult = .success(stubUser)
+
+        await sut.restore()
+
+        XCTAssertTrue(sut.isLoggedIn)
+        XCTAssertEqual(sut.userInfo?.userId, 1)
+        XCTAssertEqual(sut.name, "도연")
+    }
+
+    func test_restore_withTokens_fetchUserFails_keepsLoggedInWithoutUserInfo() async {
+        provider.hasTokensResult = true
+        provider.fetchUserResult = .failure(MockUserError.fetchFailed)
+
+        await sut.restore()
+
+        XCTAssertTrue(sut.isLoggedIn)
+        XCTAssertNil(sut.userInfo)
+        XCTAssertEqual(sut.name, "리포토")
+    }
+
+    // MARK: - login
+
+    func test_login_success_setsLoggedInAndUserInfo() async throws {
+        provider.fetchUserResult = .success(stubUser)
+
+        try await sut.login(id: "dodle", password: "pw")
+
+        XCTAssertTrue(sut.isLoggedIn)
+        XCTAssertEqual(sut.userInfo?.name, "도연")
+        XCTAssertEqual(provider.lastLoginId, "dodle")
+        XCTAssertEqual(provider.lastPassword, "pw")
+    }
+
+    func test_login_failure_throwsAndStaysLoggedOut() async {
+        provider.loginResult = .failure(MockUserError.loginFailed)
+
+        do {
+            try await sut.login(id: "dodle", password: "pw")
+            XCTFail("로그인 실패 시 에러가 throw되어야 한다")
+        } catch {}
+
+        XCTAssertFalse(sut.isLoggedIn)
+        XCTAssertEqual(provider.fetchUserCallCount, 0)
+    }
+
+    // MARK: - logout
+
+    func test_logout_clearsSessionState() async throws {
+        provider.fetchUserResult = .success(stubUser)
+        try await sut.login(id: "dodle", password: "pw")
+
+        await sut.logout()
+
+        XCTAssertFalse(sut.isLoggedIn)
+        XCTAssertNil(sut.userInfo)
+        XCTAssertEqual(provider.logoutCallCount, 1)
+    }
+
+    func test_logout_serverFailure_stillClearsLocalState() async throws {
+        provider.fetchUserResult = .success(stubUser)
+        provider.logoutResult = .failure(MockUserError.logoutFailed)
+        try await sut.login(id: "dodle", password: "pw")
+
+        await sut.logout()
+
+        XCTAssertFalse(sut.isLoggedIn)
+        XCTAssertNil(sut.userInfo)
+    }
+
+    // MARK: - 토큰 리프레시 실패 콜백
+
+    func test_refreshFailedCallback_forcesLogout() async throws {
+        provider.fetchUserResult = .success(stubUser)
+        try await sut.login(id: "dodle", password: "pw")
+        XCTAssertTrue(sut.isLoggedIn)
+
+        provider.onRefreshFailed?()
+        // 콜백이 Task { @MainActor }로 감싸 실행되므로 메인 액터에 제어를 양보한다
+        for _ in 0..<10 where sut.isLoggedIn {
+            await Task.yield()
+        }
+
+        XCTAssertFalse(sut.isLoggedIn)
+        XCTAssertNil(sut.userInfo)
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

- [x] 코드 리팩토링

## 🛠️ 작업내용

`LoginViewModel`에 섞여 있던 **폼 상태**와 **앱 전역 세션/인증 상태**의 관심사를 분리했습니다.

- **`SessionStore` 신규** — 인증/세션 소유
  - `isLoggedIn`, `userInfo`, `name`
  - `restore()`(자동 로그인 복원) / `login()` / `logout()` / `forceLogout()`
  - 인증 UseCase 호출을 담당하고 실패는 `throw`로 알림 (로딩/에러 등 화면 표현 상태는 갖지 않음)
  - refresh 실패 콜백 배선을 이관
- **`LoginViewModel` 슬림화** — 폼 표현만 (`loginId`/`password`/`isLoading`/`errorMessage`), 로그인은 `session.login()`에 위임
- **`ContentView`** — `SessionStore`를 `@State`로 소유, `isLoggedIn`으로 루트 분기, `.task`로 자동 로그인 복원을 루트에서 수행
- **`LoginView`** — `session` 주입받아 `LoginViewModel`을 `@State`로 생성, 기존 `onAppear` 제거

### 흐름
```
LoginView → LoginViewModel.login() → SessionStore.login() → UseCase → Repository → HTTP
              (로딩/에러 표현)          (인증 + isLoggedIn 전환)
```

## 📋 추후 진행 상황

- 로그아웃/프로필 UI를 `SessionStore`에 연결
- `SessionStore` 단위 테스트 (로그인/복원/강제 로그아웃 시나리오)

## 📌 리뷰 포인트

- 관심사 분리 방향(세션=인증 로직·throw, 폼 VM=화면 표현)이 적절한지
- 로그인 성공 후 `fetchUser()` 실패를 **조용히 무시**하도록 변경함 (이미 로그인은 성공, 프로필만 미로딩 → 비치명적 처리). 에러 노출은 추후 프로필 화면 관심사로 분리 예정
- 자동 로그인 복원(`restore`)을 LoginView가 아닌 앱 루트(`ContentView`)에서 수행하도록 이동

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 앱 로그인 상태가 세션 기반으로 전환되어, 실행 시 이전 세션을 자동으로 복원합니다.
  * 로그인 화면이 세션을 기준으로 표시되도록 개선되었습니다.
* **Bug Fixes**
  * 로그인/로그아웃 시 상태 전이가 더 일관되게 반영되며, 갱신 실패 시 안전하게 로그아웃됩니다.
* **Tests**
  * 세션 복원, 로그인 성공/실패, 로그아웃 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->