### PR TITLE
[Refactor] PhotoMetadataExtractor를 Domain→Data로 이동 (Domain 순수성 회복)

### DIFF
--- a/Rephoto_iOS/Core/DIContainer/AppContainer.swift
+++ b/Rephoto_iOS/Core/DIContainer/AppContainer.swift
@@ -53,6 +53,12 @@ extension Container: @retroactive AutoRegistering {
         }.singleton
     }
 
+    // MARK: - Services
+
+    private var photoMetadataExtractor: Factory<PhotoMetadataExtractorProtocol> {
+        self { PhotoMetadataExtractor() }
+    }
+
     // MARK: - UseCaseProviders
 
     var homeUseCaseProvider: Factory<HomeUseCaseProviderProtocol> {
@@ -60,7 +66,8 @@ extension Container: @retroactive AutoRegistering {
             HomeUseCaseProvider(
                 photoRepository: self.photoRepository.resolve(),
                 tagRepository: self.tagRepository.resolve(),
-                descriptionRepository: self.descriptionRepository.resolve()
+                descriptionRepository: self.descriptionRepository.resolve(),
+                metadataExtractor: self.photoMetadataExtractor.resolve()
             )
         }
     }

--- a/Rephoto_iOS/Features/Home/Data/Services/PhotoMetadataExtractor.swift
+++ b/Rephoto_iOS/Features/Home/Data/Services/PhotoMetadataExtractor.swift
@@ -5,15 +5,13 @@
 //  Created by 김도연 on 5/19/26.
 //
 
-import PhotosUI
-import SwiftUI
+import Foundation
 import ImageIO
 import UniformTypeIdentifiers
 
-struct PhotoMetadataExtractor {
-    static func extract(from item: PhotosPickerItem) async -> PhotoUploadItem? {
-        guard let data = try? await item.loadTransferable(type: Data.self),
-              let source = CGImageSourceCreateWithData(data as CFData, nil),
+struct PhotoMetadataExtractor: PhotoMetadataExtractorProtocol {
+    func extract(from imageData: Data, identifier: String?) async -> PhotoUploadItem? {
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
               let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any]
         else { return nil }
 
@@ -31,9 +29,9 @@ struct PhotoMetadataExtractor {
         let longitude = gps?["Longitude"] as? Double ?? 0.0
 
         // 파일 이름
-        // itemIdentifier는 "UUID/L0/001"처럼 슬래시를 포함할 수 있어, 그대로 쓰면
+        // identifier는 "UUID/L0/001"처럼 슬래시를 포함할 수 있어, 그대로 쓰면
         // appendingPathComponent가 하위 경로로 해석해 임시 파일 저장이 실패한다.
-        let rawName = item.itemIdentifier ?? UUID().uuidString
+        let rawName = identifier ?? UUID().uuidString
         let fileName = rawName.replacingOccurrences(of: "/", with: "_")
 
         // 업로드 전 다운샘플 + JPEG 압축 (원본 그대로 올리던 것을 ImageIO로 교체)
@@ -43,7 +41,7 @@ struct PhotoMetadataExtractor {
         }
 
         #if DEBUG
-        let beforeKB = data.count / 1024
+        let beforeKB = imageData.count / 1024
         let afterKB = compressed.count / 1024
         let pxW = properties[kCGImagePropertyPixelWidth as String] as? Int ?? 0
         let pxH = properties[kCGImagePropertyPixelHeight as String] as? Int ?? 0
@@ -72,7 +70,7 @@ struct PhotoMetadataExtractor {
     /// ImageIO로 디코드 시점에 다운샘플 → JPEG 인코딩.
     /// `UIImage(data:).jpegData()`는 풀해상도 비트맵을 메모리에 올려서 4000x3000 기준 ~36MB가 튀지만,
     /// `CGImageSourceCreateThumbnailAtIndex`는 목표 크기로만 디코드해 피크 메모리를 크게 낮춘다.
-    private static func downsampledJPEG(
+    private func downsampledJPEG(
         from source: CGImageSource,
         maxPixelSize: CGFloat,
         quality: CGFloat

--- a/Rephoto_iOS/Features/Home/Domain/Interfaces/PhotoMetadataExtractorProtocol.swift
+++ b/Rephoto_iOS/Features/Home/Domain/Interfaces/PhotoMetadataExtractorProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  PhotoMetadataExtractorProtocol.swift
+//  Rephoto_iOS
+//
+//  Created by Doyeon Kim on 7/10/26.
+//
+
+import Foundation
+
+/// 이미지 원본 데이터에서 업로드용 메타데이터(위치/촬영시간)와 압축본을 추출하는 계약.
+/// 구현체(ImageIO/파일 I/O)는 Data 계층에 있다.
+protocol PhotoMetadataExtractorProtocol {
+    func extract(from imageData: Data, identifier: String?) async -> PhotoUploadItem?
+}

--- a/Rephoto_iOS/Features/Home/Domain/UseCases/ExtractPhotoMetadataUseCaseProtocol.swift
+++ b/Rephoto_iOS/Features/Home/Domain/UseCases/ExtractPhotoMetadataUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  ExtractPhotoMetadataUseCaseProtocol.swift
+//  Rephoto_iOS
+//
+//  Created by Doyeon Kim on 7/10/26.
+//
+
+import Foundation
+
+protocol ExtractPhotoMetadataUseCaseProtocol {
+    func execute(imageData: Data, identifier: String?) async -> PhotoUploadItem?
+}

--- a/Rephoto_iOS/Features/Home/Domain/UseCases/Implementations/ExtractPhotoMetadataUseCase.swift
+++ b/Rephoto_iOS/Features/Home/Domain/UseCases/Implementations/ExtractPhotoMetadataUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  ExtractPhotoMetadataUseCase.swift
+//  Rephoto_iOS
+//
+//  Created by Doyeon Kim on 7/10/26.
+//
+
+import Foundation
+
+final class ExtractPhotoMetadataUseCase: ExtractPhotoMetadataUseCaseProtocol {
+    private let extractor: PhotoMetadataExtractorProtocol
+
+    init(extractor: PhotoMetadataExtractorProtocol) {
+        self.extractor = extractor
+    }
+
+    func execute(imageData: Data, identifier: String?) async -> PhotoUploadItem? {
+        await extractor.extract(from: imageData, identifier: identifier)
+    }
+}

--- a/Rephoto_iOS/Features/Home/Presentation/Preview/MockHomeUseCaseProvider.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Preview/MockHomeUseCaseProvider.swift
@@ -11,6 +11,7 @@ import Foundation
 final class MockHomeUseCaseProvider: HomeUseCaseProviderProtocol {
     func makeGetPhotosUseCase() -> GetPhotosUseCaseProtocol { MockGetPhotosUseCase() }
     func makeUploadPhotosUseCase() -> UploadPhotosUseCaseProtocol { MockUploadPhotosUseCase() }
+    func makeExtractPhotoMetadataUseCase() -> ExtractPhotoMetadataUseCaseProtocol { MockExtractPhotoMetadataUseCase() }
     func makeDeletePhotoUseCase() -> DeletePhotoUseCaseProtocol { MockDeletePhotoUseCase() }
     func makeGetTagsUseCase() -> GetTagsUseCaseProtocol { MockGetTagsUseCase() }
     func makeAddTagUseCase() -> AddTagUseCaseProtocol { MockAddTagUseCase() }
@@ -39,6 +40,10 @@ private struct MockGetPhotosUseCase: GetPhotosUseCaseProtocol {
 
 private struct MockUploadPhotosUseCase: UploadPhotosUseCaseProtocol {
     func execute(items: [PhotoUploadItem]) async throws {}
+}
+
+private struct MockExtractPhotoMetadataUseCase: ExtractPhotoMetadataUseCaseProtocol {
+    func execute(imageData: Data, identifier: String?) async -> PhotoUploadItem? { nil }
 }
 
 private struct MockDeletePhotoUseCase: DeletePhotoUseCaseProtocol {

--- a/Rephoto_iOS/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Provider/HomeUseCaseProvider.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol HomeUseCaseProviderProtocol {
     func makeGetPhotosUseCase() -> GetPhotosUseCaseProtocol
     func makeUploadPhotosUseCase() -> UploadPhotosUseCaseProtocol
+    func makeExtractPhotoMetadataUseCase() -> ExtractPhotoMetadataUseCaseProtocol
     func makeDeletePhotoUseCase() -> DeletePhotoUseCaseProtocol
     func makeGetTagsUseCase() -> GetTagsUseCaseProtocol
     func makeAddTagUseCase() -> AddTagUseCaseProtocol
@@ -21,15 +22,18 @@ final class HomeUseCaseProvider: HomeUseCaseProviderProtocol {
     private let photoRepository: PhotoRepositoryProtocol
     private let tagRepository: TagRepositoryProtocol
     private let descriptionRepository: DescriptionRepositoryProtocol
+    private let metadataExtractor: PhotoMetadataExtractorProtocol
 
     init(
         photoRepository: PhotoRepositoryProtocol,
         tagRepository: TagRepositoryProtocol,
-        descriptionRepository: DescriptionRepositoryProtocol
+        descriptionRepository: DescriptionRepositoryProtocol,
+        metadataExtractor: PhotoMetadataExtractorProtocol
     ) {
         self.photoRepository = photoRepository
         self.tagRepository = tagRepository
         self.descriptionRepository = descriptionRepository
+        self.metadataExtractor = metadataExtractor
     }
 
     func makeGetPhotosUseCase() -> GetPhotosUseCaseProtocol {
@@ -38,6 +42,10 @@ final class HomeUseCaseProvider: HomeUseCaseProviderProtocol {
 
     func makeUploadPhotosUseCase() -> UploadPhotosUseCaseProtocol {
         UploadPhotosUseCase(repository: photoRepository)
+    }
+
+    func makeExtractPhotoMetadataUseCase() -> ExtractPhotoMetadataUseCaseProtocol {
+        ExtractPhotoMetadataUseCase(extractor: metadataExtractor)
     }
 
     func makeDeletePhotoUseCase() -> DeletePhotoUseCaseProtocol {

--- a/Rephoto_iOS/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -45,10 +45,16 @@ final class HomeViewModel {
         isLoading = true
         errorMessage = nil
 
+        let extractUseCase = provider.makeExtractPhotoMetadataUseCase()
         let items = await withTaskGroup(of: PhotoUploadItem?.self, returning: [PhotoUploadItem].self) { group in
             for pickerItem in pickerItems {
                 group.addTask {
-                    await PhotoMetadataExtractor.extract(from: pickerItem)
+                    // PhotosPickerItem(SwiftUI) → Data 변환까지만 Presentation이 담당하고,
+                    // 메타데이터 추출/압축은 Domain 계약(UseCase) 뒤의 Data 구현체가 수행
+                    guard let data = try? await pickerItem.loadTransferable(type: Data.self) else {
+                        return nil
+                    }
+                    return await extractUseCase.execute(imageData: data, identifier: pickerItem.itemIdentifier)
                 }
             }
             var results: [PhotoUploadItem] = []


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

Closes #35

`PhotoMetadataExtractor`가 `Features/Home/Domain/Services/`에 있으면서 PhotosUI·SwiftUI·ImageIO를 import해 **"Domain: 순수 Swift, 외부 의존 없음"** 규칙을 위반하던 것을 해소했습니다.

### 1. Domain 계약 추가
- `Domain/Interfaces/PhotoMetadataExtractorProtocol.swift` — `extract(from imageData: Data, identifier: String?) async -> PhotoUploadItem?`. 입력이 `PhotosPickerItem`이 아닌 `Data`라서 Domain에 플랫폼 타입이 남지 않음
- `ExtractPhotoMetadataUseCaseProtocol` + `ExtractPhotoMetadataUseCase` — 기존 UseCase 패턴과 동일 구조로 extractor 계약에 위임

### 2. 구현체를 Data 계층으로 이동
- `Domain/Services/PhotoMetadataExtractor.swift` → `Data/Services/PhotoMetadataExtractor.swift` (git rename 인식)
- PhotosUI/SwiftUI import 제거, `Foundation`·`ImageIO`·`UniformTypeIdentifiers`만 사용
- static 함수 → 프로토콜 준수 인스턴스 메서드 전환 (기존 심볼명 보존)
- EXIF/GPS 추출, 다운샘플+JPEG 압축(#34), 임시 파일 저장 로직은 그대로

### 3. DI 배선
- `AppContainer`에 `photoMetadataExtractor` 팩토리 등록 → `HomeUseCaseProvider` 생성자 주입
- `HomeUseCaseProviderProtocol`에 `makeExtractPhotoMetadataUseCase()` 추가, Mock provider에도 반영

### 4. 호출부 연결
- `HomeViewModel.handlePickedPhotos`: `PhotosPickerItem → Data` 변환(`loadTransferable`)까지만 Presentation이 담당하고, 추출은 UseCase 호출로 위임
- TaskGroup 병렬 처리 구조는 기존 그대로 유지

## 📋 추후 진행 상황

- SwiftUI 관찰 성능·뷰 구조 개선 및 UI 마무리 (#40~#43)

## 📌 리뷰 포인트

- Domain 계약의 입력 시그니처(`Data + identifier`)가 적절한지 — `PhotosPickerItem` 로딩을 Presentation(ViewModel)에 두는 경계 설정
- 이동한 구현체의 동작이 기존과 동일한지 (추출/압축/임시 파일 저장 로직은 diff상 변경 없음)
- `AppContainer`의 extractor 팩토리 등록 위치(Services 섹션 신설)

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사진 데이터를 기반으로 촬영 시간·위치 등의 메타데이터와 업로드용 압축 이미지를 추출합니다.
  * 사진 처리 기능을 사용 사례로 분리해 안정적으로 관리할 수 있습니다.

* **버그 수정**
  * 사진 데이터 변환에 실패한 항목이 전체 처리를 중단하지 않고 해당 항목만 제외되도록 개선했습니다.

* **개선**
  * 사진 식별자를 활용해 파일명을 생성하며, 파일명에 포함된 슬래시를 안전하게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->