### PR TITLE
[Refactor] 다운샘플 목표 크기를 서브샘플 경계에 동적 정렬 (#49)

### DIFF
--- a/Rephoto_iOS/Features/Home/Data/Services/PhotoMetadataExtractor.swift
+++ b/Rephoto_iOS/Features/Home/Data/Services/PhotoMetadataExtractor.swift
@@ -36,17 +36,25 @@ struct PhotoMetadataExtractor: PhotoMetadataExtractorProtocol {
 
         // 업로드 전 다운샘플 + JPEG 압축 (원본 그대로 올리던 것을 ImageIO로 교체)
         // 위치/촬영시간은 위에서 EXIF로 이미 추출했으므로, 압축본에 메타가 빠져도 무방
-        guard let compressed = downsampledJPEG(from: source, maxPixelSize: 2048, quality: 0.8) else {
+        //
+        // 목표 크기는 JPEG 1/2ⁿ 서브샘플 디코드 경계에 맞춰 동적 계산한다.
+        // 경계에 안 맞으면(예: 4032px 원본에 2048 요청) ImageIO가 풀사이즈로 디코드한 뒤
+        // 축소해서 피크 메모리가 2배로 뛴다 — UploadMemoryBenchmark 실측 +50MB → +28MB
+        let pxW = properties[kCGImagePropertyPixelWidth as String] as? Int ?? 0
+        let pxH = properties[kCGImagePropertyPixelHeight as String] as? Int ?? 0
+        let longerSide = max(pxW, pxH)
+        var targetPixelSize: CGFloat = longerSide > 0 ? CGFloat(longerSide) : 2016
+        while targetPixelSize > 2048 { targetPixelSize /= 2 }
+
+        guard let compressed = downsampledJPEG(from: source, maxPixelSize: targetPixelSize, quality: 0.8) else {
             return nil
         }
 
         #if DEBUG
         let beforeKB = imageData.count / 1024
         let afterKB = compressed.count / 1024
-        let pxW = properties[kCGImagePropertyPixelWidth as String] as? Int ?? 0
-        let pxH = properties[kCGImagePropertyPixelHeight as String] as? Int ?? 0
         let ratio = beforeKB == 0 ? 0 : afterKB * 100 / beforeKB
-        print("📷 [압축] \(pxW)x\(pxH)  \(beforeKB)KB → \(afterKB)KB  (\(ratio)%)")
+        print("📷 [압축] \(pxW)x\(pxH) → 목표 \(Int(targetPixelSize))px  \(beforeKB)KB → \(afterKB)KB  (\(ratio)%)")
         #endif
 
         // 임시 파일 저장 (실패 시 업로드 불가하므로 nil 반환)
@@ -68,8 +76,9 @@ struct PhotoMetadataExtractor: PhotoMetadataExtractorProtocol {
     }
 
     /// ImageIO로 디코드 시점에 다운샘플 → JPEG 인코딩.
-    /// `UIImage(data:).jpegData()`는 풀해상도 비트맵을 메모리에 올려서 4000x3000 기준 ~36MB가 튀지만,
-    /// `CGImageSourceCreateThumbnailAtIndex`는 목표 크기로만 디코드해 피크 메모리를 크게 낮춘다.
+    /// 주의: 서브샘플(1/2ⁿ) 디코드 경로는 `원본/2ⁿ ≥ maxPixelSize`일 때만 성립한다.
+    /// 경계에 안 맞는 값을 넘기면 풀사이즈 디코드 후 축소로 떨어져 피크 메모리 이점이 사라지므로
+    /// (UploadMemoryBenchmark 실측), 호출부에서 원본 크기 기반으로 경계에 맞는 목표를 계산해 넘긴다.
     private func downsampledJPEG(
         from source: CGImageSource,
         maxPixelSize: CGFloat,


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

Closes #49

`UploadMemoryBenchmark`(#48) 실측으로 발견한 업로드 전처리 풀사이즈 디코드 문제를 수정합니다.

### 원인 (옵션 대조 실험으로 격리)

JPEG의 서브샘플(1/2ⁿ) 디코드 경로는 `원본/2ⁿ ≥ maxPixelSize`일 때만 성립하는데, 기존 고정값 `maxPixelSize: 2048`은 4032px 원본의 1/2(2016)과 경계가 어긋나 ImageIO가 **풀사이즈 RGBA(~47MB)를 디코드한 뒤 축소**하고 있었습니다. EXIF 회전(`ThumbnailWithTransform`)은 +4MB에 불과해 주범이 아니었습니다.

### 수정

- `PhotoMetadataExtractor`: 목표 크기를 원본 긴 변 기반 동적 계산으로 변경 — 2로 나눠가며 2048 이하가 되는 첫 값 (4032→2016, 5712→1428, 8064→2016). 모든 입력 크기에서 서브샘플 경로가 보장되고, 경계에 안 맞는 소형 입력은 기존과 동일하게 동작(회귀 없음)
- 실측과 모순되던 주석("목표 크기로만 디코드해 피크를 낮춘다")을 경계 조건 설명으로 교체

### 실측 검증 (수정 후 `test_current_downsampleExtract_peakDelta` 재실행)

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| 메모리 피크 delta | +50MB | **+28.7MB (−43%)** |
| 처리 시간 | 0.146s | **0.12s (−20%)** |
| 페이로드 | 1547KB | 1540KB (동일) |
| EXIF 회전 보정 | 유지 | 유지 |

## 📋 추후 진행 상황

- #40 Home 파생 컬렉션 벤치마크 후속 PR (계산 프로퍼티 vs didSet 캐싱 A/B)

## 📌 리뷰 포인트

- 동적 계산 로직: `while targetPixelSize > 2048 { targetPixelSize /= 2 }` — 원본이 2048 이하면 원본 크기 그대로(축소 불필요), 픽셀 크기를 못 읽으면 2016 폴백
- 24MP(5712px) 사진은 출력이 1428px로 작아지는 트레이드오프 — AI 태깅·그리드 썸네일 용도에는 충분하다고 판단

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)