### PR TITLE
[Design] Search·Settings·프로필 시트 Liquid Glass 디자인 반영

### DIFF
--- a/Rephoto-iOS-Info.plist
+++ b/Rephoto-iOS-Info.plist
@@ -6,5 +6,7 @@
 	<string>$(BASE_URL)</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>숨겨진 민감한 사진을 보려면 Face ID 인증이 필요해요.</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Rephoto_iOS/Features/Home/Presentation/Preview/MockHomeUseCaseProvider.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Preview/MockHomeUseCaseProvider.swift
@@ -24,8 +24,9 @@ final class MockHomeUseCaseProvider: HomeUseCaseProviderProtocol {
 
 /// Resources/MockImages의 실제 사진과 1:1로 매칭되는 데모 픽스처.
 /// 태그·AI 설명·좌표·촬영일이 사진 내용/EXIF 기준으로 작성되어 있음.
-/// photoId는 배열 순서(최신순) 기반 index + 1 — GetPhotos/GetTags/GetDescription이 모두 이 데이터를 공유
-private enum MockPhotoFixtures {
+/// photoId는 배열 순서(최신순) 기반 index + 1 — GetPhotos/GetTags/GetDescription이 모두 이 데이터를 공유.
+/// Search 데모(MockSearchUseCaseProvider)도 같은 사진을 앨범/검색 결과로 재사용한다
+enum MockPhotoFixtures {
     struct Entry {
         let fileName: String
         let tags: [String]
@@ -146,6 +147,21 @@ private enum MockPhotoFixtures {
         return entries[photoId - 1]
     }
 
+    /// 배열 index 기준으로 Photo 도메인 모델 생성 (photoId = index + 1)
+    static func photo(at index: Int) -> Photo {
+        let entry = entries[index]
+        return Photo(
+            photoId: index + 1,
+            imageUrl: imageUrl(fileName: entry.fileName),
+            latitude: entry.latitude,
+            longitude: entry.longitude,
+            createdAt: isoFormatter.date(from: entry.createdAt) ?? Date(),
+            fileName: entry.fileName,
+            tags: entry.tags,
+            isSensitive: entry.isSensitive
+        )
+    }
+
     static func imageUrl(fileName: String) -> URL {
         let name = (fileName as NSString).deletingPathExtension
         let ext = (fileName as NSString).pathExtension
@@ -161,18 +177,7 @@ private enum MockPhotoFixtures {
 
 private struct MockGetPhotosUseCase: GetPhotosUseCaseProtocol {
     func execute() async throws -> [Photo] {
-        MockPhotoFixtures.entries.enumerated().map { index, entry in
-            Photo(
-                photoId: index + 1,
-                imageUrl: MockPhotoFixtures.imageUrl(fileName: entry.fileName),
-                latitude: entry.latitude,
-                longitude: entry.longitude,
-                createdAt: MockPhotoFixtures.isoFormatter.date(from: entry.createdAt) ?? Date(),
-                fileName: entry.fileName,
-                tags: entry.tags,
-                isSensitive: entry.isSensitive
-            )
-        }
+        MockPhotoFixtures.entries.indices.map { MockPhotoFixtures.photo(at: $0) }
     }
 }
 

--- a/Rephoto_iOS/Features/Home/Presentation/Views/HomeSheetView.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/HomeSheetView.swift
@@ -9,25 +9,152 @@ import SwiftUI
 
 struct HomeSheetView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(SessionStore.self) private var session
+
+    @State private var showSettings = false
+    @State private var showLogoutConfirmation = false
+    @State private var sheetDetent: PresentationDetent = .medium
 
     var body: some View {
         NavigationStack {
-            List {
-                NavigationLink("설정") {
-                    // SettingsView()
-                    Text("설정")
+            VStack(spacing: 20) {
+                ProfileCard(name: session.name)
+
+                SettingsLinkRow {
+                    // 설정은 전체 높이가 필요하므로 push와 함께 시트를 확장
+                    sheetDetent = .large
+                    showSettings = true
                 }
+
+                LogoutCard {
+                    showLogoutConfirmation = true
+                }
+
+                Spacer()
             }
+            .padding(.horizontal, 22)
+            .padding(.top, 24)
+            .background(Color.base.ignoresSafeArea())
             .navigationTitle("내 정보")
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(isPresented: $showSettings) {
+                SettingsView()
+            }
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("닫기") {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
                         dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
                     }
                 }
             }
+            .confirmationDialog("로그아웃하시겠습니까?", isPresented: $showLogoutConfirmation, titleVisibility: .visible) {
+                Button("로그아웃", role: .destructive) {
+                    Task { await session.logout() }
+                }
+            }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large], selection: $sheetDetent)
+        .onChange(of: showSettings) { _, isShowing in
+            // 설정에서 돌아오면 시트를 원래 높이로 복귀
+            if !isShowing { sheetDetent = .medium }
+        }
     }
 }
+
+// MARK: - ProfileCard
+
+/// 아바타(이름 첫 글자) + 이름 글래스 프로필 카드
+private struct ProfileCard: View {
+    let name: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(name.prefix(1))
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 52, height: 52)
+                .background(
+                    LinearGradient(colors: [.lightGreen, .mainGreen], startPoint: .top, endPoint: .bottom),
+                    in: Circle()
+                )
+
+            Text(name)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.labelPrimary)
+
+            Spacer()
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 16)
+        .frame(height: 78)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+// MARK: - SettingsLinkRow
+
+/// 설정 화면으로 이동하는 글래스 행 (그린 아이콘 타일 + chevron)
+private struct SettingsLinkRow: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: "gearshape.fill")
+                    .font(.system(size: 15))
+                    .foregroundStyle(.white)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        Color(red: 0x5B / 255, green: 0x8C / 255, blue: 0x63 / 255),
+                        in: RoundedRectangle(cornerRadius: 8)
+                    )
+
+                Text("설정")
+                    .font(.system(size: 17))
+                    .foregroundStyle(.labelPrimary)
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.labelTertiary)
+            }
+            .padding(.leading, 14)
+            .padding(.trailing, 16)
+            .frame(height: 56)
+            .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - LogoutCard
+
+/// 로그아웃 글래스 카드 버튼
+private struct LogoutCard: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("로그아웃")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(red: 0xE2 / 255, green: 0x33 / 255, blue: 0x2F / 255))
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+                .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#if DEBUG
+#Preview("HomeSheet") {
+    Text("Home")
+        .sheet(isPresented: .constant(true)) {
+            HomeSheetView()
+                .environment(SessionStore(provider: MockUserUseCaseProvider()))
+        }
+}
+#endif

--- a/Rephoto_iOS/Features/Home/Presentation/Views/HomeSheetView.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/HomeSheetView.swift
@@ -63,36 +63,6 @@ struct HomeSheetView: View {
     }
 }
 
-// MARK: - ProfileCard
-
-/// 아바타(이름 첫 글자) + 이름 글래스 프로필 카드
-private struct ProfileCard: View {
-    let name: String
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Text(name.prefix(1))
-                .font(.system(size: 22, weight: .bold))
-                .foregroundStyle(.white)
-                .frame(width: 52, height: 52)
-                .background(
-                    LinearGradient(colors: [.lightGreen, .mainGreen], startPoint: .top, endPoint: .bottom),
-                    in: Circle()
-                )
-
-            Text(name)
-                .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(.labelPrimary)
-
-            Spacer()
-        }
-        .padding(.leading, 14)
-        .padding(.trailing, 16)
-        .frame(height: 78)
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16))
-    }
-}
-
 // MARK: - SettingsLinkRow
 
 /// 설정 화면으로 이동하는 글래스 행 (그린 아이콘 타일 + chevron)
@@ -125,25 +95,6 @@ private struct SettingsLinkRow: View {
             .padding(.trailing, 16)
             .frame(height: 56)
             .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
-        }
-        .buttonStyle(.plain)
-    }
-}
-
-// MARK: - LogoutCard
-
-/// 로그아웃 글래스 카드 버튼
-private struct LogoutCard: View {
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text("로그아웃")
-                .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(red: 0xE2 / 255, green: 0x33 / 255, blue: 0x2F / 255))
-                .frame(maxWidth: .infinity)
-                .frame(height: 54)
-                .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
         }
         .buttonStyle(.plain)
     }

--- a/Rephoto_iOS/Features/Home/Presentation/Views/HomeView.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/HomeView.swift
@@ -38,6 +38,7 @@ struct HomeView: View {
                     )
                 }
             }
+            .background(Color.base.ignoresSafeArea())
             .navigationTitle("앨범")
             .navigationDestination(for: Photo.self) { photo in
                 PhotoInfoView(photo: photo, provider: vm.provider)

--- a/Rephoto_iOS/Features/Search/Presentation/Preview/MockSearchUseCaseProvider.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Preview/MockSearchUseCaseProvider.swift
@@ -22,42 +22,62 @@ final class MockSearchUseCaseProvider: SearchUseCaseProviderProtocol {
     }
 }
 
+// MARK: - MockAlbumFixtures
+
+/// 홈 데모 사진(MockPhotoFixtures)을 태그 테마별로 묶은 앨범 구성.
+/// tagId는 배열 순서 기반 index + 1
+private enum MockAlbumFixtures {
+    static let groups: [(tagName: String, fileNames: [String])] = [
+        ("커피", ["IMG_0813.jpeg", "IMG_0356.jpeg", "IMG_0673.jpeg"]),
+        ("남산", ["IMG_0275.jpeg", "IMG_0689.jpeg", "IMG_2015.JPG"]),
+        ("봄", ["IMG_9898.jpeg", "IMG_0871.jpeg"]),
+        ("바다", ["IMG_9563.jpeg"]),
+        ("한강", ["IMG_0099.jpeg"]),
+        ("고양이", ["IMG_8415.JPG"]),
+    ]
+
+    /// 파일명 목록을 홈 픽스처의 Photo(동일 photoId)로 변환
+    static func photos(fileNames: [String]) -> [Photo] {
+        fileNames.compactMap { fileName in
+            guard let index = MockPhotoFixtures.entries.firstIndex(where: { $0.fileName == fileName }) else {
+                return nil
+            }
+            return MockPhotoFixtures.photo(at: index)
+        }
+    }
+}
+
 // MARK: - Mock UseCases
 
 private struct MockGetAlbumsUseCase: GetAlbumsUseCaseProtocol {
     func execute() async throws -> [Album] {
-        [
-            Album(tagId: 1, tagName: "바다"),
-            Album(tagId: 2, tagName: "산"),
-            Album(tagId: 3, tagName: "카페"),
-            Album(tagId: 4, tagName: "여행"),
-        ]
+        MockAlbumFixtures.groups.enumerated().map { index, group in
+            Album(tagId: index + 1, tagName: group.tagName)
+        }
     }
 }
 
 private struct MockGetAlbumPhotosUseCase: GetAlbumPhotosUseCaseProtocol {
     func execute(tagId: Int) async throws -> [Photo] {
-        (1...6).map { i in
-            Photo(
-                photoId: tagId * 100 + i,
-                imageUrl: URL(string: "https://picsum.photos/seed/\(tagId)-\(i)/400")!,
-                latitude: 37.5665,
-                longitude: 126.9780,
-                createdAt: Date(),
-                fileName: "photo_\(i).jpg",
-                tags: ["mock"],
-                isSensitive: false
-            )
-        }
+        guard MockAlbumFixtures.groups.indices.contains(tagId - 1) else { return [] }
+        return MockAlbumFixtures.photos(fileNames: MockAlbumFixtures.groups[tagId - 1].fileNames)
     }
 }
 
 private struct MockSearchUseCase: SearchUseCaseProtocol {
     func execute(query: String) async throws -> [SearchResult] {
-        (1...4).map { i in
-            SearchResult(
-                imageUrl: URL(string: "https://picsum.photos/seed/search-\(i)/400")!,
-                photoId: i
+        let query = query.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return [] }
+
+        // 태그/AI 설명에서 검색어 매칭 (민감 사진 제외)
+        return MockPhotoFixtures.entries.enumerated().compactMap { index, entry in
+            guard !entry.isSensitive else { return nil }
+            let matched = entry.tags.contains { $0.localizedCaseInsensitiveContains(query) }
+                || entry.description.localizedCaseInsensitiveContains(query)
+            guard matched else { return nil }
+            return SearchResult(
+                imageUrl: MockPhotoFixtures.imageUrl(fileName: entry.fileName),
+                photoId: index + 1
             )
         }
     }

--- a/Rephoto_iOS/Features/Search/Presentation/ViewModels/AlbumViewModel.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/ViewModels/AlbumViewModel.swift
@@ -10,8 +10,15 @@ import Foundation
 @Observable
 final class AlbumViewModel {
     let provider: SearchUseCaseProviderProtocol
-    
+
+    /// 앨범 카드에 표시할 대표 썸네일과 사진 수
+    struct AlbumPreview {
+        let thumbnailUrl: URL?
+        let photoCount: Int
+    }
+
     private(set) var albums: [Album] = []
+    private(set) var albumPreviews: [Int: AlbumPreview] = [:]
     private(set) var albumPhotos: [Photo] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
@@ -30,6 +37,15 @@ final class AlbumViewModel {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+
+        // 앨범 목록을 먼저 노출한 뒤, 카드용 대표 사진/장수는 뒤이어 채운다
+        for album in albums {
+            guard let photos = try? await provider.getAlbumPhotos().execute(tagId: album.tagId) else { continue }
+            albumPreviews[album.tagId] = AlbumPreview(
+                thumbnailUrl: photos.first?.imageUrl,
+                photoCount: photos.count
+            )
+        }
     }
 
     @MainActor

--- a/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
@@ -10,16 +10,20 @@ import Foundation
 @Observable
 class SearchViewModel {
     let provider: SearchUseCaseProviderProtocol
-    
+    private let getPhotosUseCase: GetPhotosUseCaseProtocol
+
     var searchResults: [SearchResult] = []
+    /// 검색 결과(photoId)를 사진 상세용 전체 Photo로 매핑하기 위한 홈 사진 색인
+    private(set) var photosById: [Int: Photo] = [:]
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     var query: String = ""
-    
-    init(provider: SearchUseCaseProviderProtocol) {
+
+    init(provider: SearchUseCaseProviderProtocol, getPhotosUseCase: GetPhotosUseCaseProtocol) {
         self.provider = provider
+        self.getPhotosUseCase = getPhotosUseCase
     }
-    
+
     @MainActor
     func search(query: String) async {
         isLoading = true
@@ -31,5 +35,11 @@ class SearchViewModel {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    @MainActor
+    func loadPhotoIndex() async {
+        guard let photos = try? await getPhotosUseCase.execute() else { return }
+        photosById = Dictionary(photos.map { ($0.photoId, $0) }, uniquingKeysWith: { first, _ in first })
     }
 }

--- a/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
@@ -15,6 +15,8 @@ class SearchViewModel {
     var searchResults: [SearchResult] = []
     /// 검색 결과(photoId)를 사진 상세용 전체 Photo로 매핑하기 위한 홈 사진 색인
     private(set) var photosById: [Int: Photo] = [:]
+    /// 색인 로드 실패 여부 — 다음 검색 시 재시도 트리거로 사용
+    private var photoIndexLoadFailed = false
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     var query: String = ""
@@ -35,11 +37,25 @@ class SearchViewModel {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+
+        // 이전에 색인 로드가 실패했다면 결과 → 상세 매핑을 위해 재시도
+        if photoIndexLoadFailed {
+            await loadPhotoIndex()
+        }
     }
 
     @MainActor
     func loadPhotoIndex() async {
-        guard let photos = try? await getPhotosUseCase.execute() else { return }
-        photosById = Dictionary(photos.map { ($0.photoId, $0) }, uniquingKeysWith: { first, _ in first })
+        do {
+            let photos = try await getPhotosUseCase.execute()
+            photosById = Dictionary(photos.map { ($0.photoId, $0) }, uniquingKeysWith: { first, _ in first })
+            photoIndexLoadFailed = false
+        } catch is CancellationError {
+            // 화면 이탈 등으로 취소된 경우는 실패로 취급하지 않음
+        } catch {
+            // 색인은 상세 화면 메타데이터 보강용 — 실패해도 검색과 상세 진입은
+            // 폴백 Photo로 동작하므로 별도 에러 노출 없이 다음 검색 시 재시도한다
+            photoIndexLoadFailed = true
+        }
     }
 }

--- a/Rephoto_iOS/Features/Search/Presentation/Views/AlbumDetailView.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Views/AlbumDetailView.swift
@@ -10,10 +10,12 @@ import NukeUI
 
 struct AlbumDetailView: View {
     let album: Album
+    let namespace: Namespace.ID
     @State private var albumVM: AlbumViewModel
 
-    init(album: Album, provider: SearchUseCaseProviderProtocol) {
+    init(album: Album, provider: SearchUseCaseProviderProtocol, namespace: Namespace.ID) {
         self.album = album
+        self.namespace = namespace
         self._albumVM = State(initialValue: AlbumViewModel(provider: provider))
     }
 
@@ -29,47 +31,155 @@ struct AlbumDetailView: View {
                     .frame(maxWidth: .infinity)
                     .padding()
             } else {
-                photoGrid
+                VStack(alignment: .leading, spacing: 20) {
+                    AlbumBanner(title: album.tagName, photos: albumVM.albumPhotos)
+
+                    Text("사진")
+                        .font(.system(size: 20, weight: .bold))
+                        .tracking(-0.3)
+                        .foregroundStyle(.labelPrimary)
+                        .padding(.leading, 4)
+
+                    AlbumPhotoGrid(photos: albumVM.albumPhotos, namespace: namespace)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
             }
         }
+        .background(Color.base.ignoresSafeArea())
         .navigationTitle(album.tagName)
+        .navigationBarTitleDisplayMode(.inline)
         .task { await albumVM.fetchAlbumPhotos(tagId: album.tagId) }
     }
+}
 
-    private var photoGrid: some View {
-        GeometryReader { geo in
-            let side: CGFloat = geo.size.width / 2 - 16
-            let cols = Array(repeating: GridItem(.fixed(side), spacing: 8), count: 2)
+// MARK: - AlbumBanner
 
-            LazyVGrid(columns: cols, spacing: 8) {
-                ForEach(albumVM.albumPhotos, id: \.photoId) { photo in
+/// 앨범 대표 사진 콜라주 + 스크림 위에 앨범명과 요약을 얹은 배너
+private struct AlbumBanner: View {
+    let title: String
+    let photos: [Photo]
+
+    private var latestDate: Date? {
+        photos.map(\.createdAt).max()
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            BannerCollage(photos: Array(photos.prefix(3)))
+
+            LinearGradient(colors: [.black.opacity(0.05), .black.opacity(0.45)], startPoint: .top, endPoint: .bottom)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("앨범")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 5)
+                    .background(.white.opacity(0.28), in: Capsule())
+                    .overlay(Capsule().stroke(.white.opacity(0.5), lineWidth: 1))
+
+                Text(title)
+                    .font(.system(size: 28, weight: .bold))
+                    .tracking(-0.5)
+                    .foregroundStyle(.white)
+
+                Text(summaryText)
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.88))
+            }
+            .padding(.leading, 22)
+        }
+        .frame(height: 138)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+        .shadow(color: .deepGreen.opacity(0.28), radius: 12, y: 12)
+    }
+
+    private var summaryText: String {
+        if let latestDate {
+            return "사진 \(photos.count)장 · 최근 \(latestDate.formatted(.dateTime.month().day()))"
+        }
+        return "사진 \(photos.count)장"
+    }
+}
+
+// MARK: - BannerCollage
+
+/// 배너 배경 — 앨범 사진 최대 3장을 가로로 이어 붙인 콜라주
+private struct BannerCollage: View {
+    let photos: [Photo]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if photos.isEmpty {
+                LinearGradient(
+                    colors: [.lightGreen, .mainGreen],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            } else {
+                ForEach(photos) { photo in
                     LazyImage(url: photo.imageUrl) { state in
                         if let image = state.image {
                             image
                                 .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: side, height: side)
-                                .clipped()
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .scaledToFill()
                         } else {
-                            Color.gray
-                                .frame(width: side, height: side)
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                            Color.gray.opacity(0.2)
                         }
                     }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 138)
+                    .clipped()
                 }
             }
-            .padding(8)
+        }
+    }
+}
+
+// MARK: - AlbumPhotoGrid
+
+/// 앨범 사진 3열 그리드 — 타일 탭 시 사진 상세로 줌 전환
+private struct AlbumPhotoGrid: View {
+    let photos: [Photo]
+    let namespace: Namespace.ID
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(photos) { photo in
+                NavigationLink(value: photo) {
+                    Color.clear
+                        .aspectRatio(1, contentMode: .fit)
+                        .overlay {
+                            LazyImage(url: photo.imageUrl) { state in
+                                if let image = state.image {
+                                    image
+                                        .resizable()
+                                        .scaledToFill()
+                                } else {
+                                    Color.gray.opacity(0.2)
+                                }
+                            }
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .matchedTransitionSource(id: photo.photoId, in: namespace)
+                }
+                .buttonStyle(.plain)
+            }
         }
     }
 }
 
 #if DEBUG
 #Preview("Album Detail") {
+    @Previewable @Namespace var namespace
     NavigationStack {
         AlbumDetailView(
-            album: Album(tagId: 1, tagName: "바다"),
-            provider: MockSearchUseCaseProvider()
+            album: Album(tagId: 1, tagName: "커피"),
+            provider: MockSearchUseCaseProvider(),
+            namespace: namespace
         )
     }
 }

--- a/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
@@ -12,13 +12,14 @@ import Factory
 struct SearchView: View {
     @State private var searchVM: SearchViewModel
     @State private var albumVM: AlbumViewModel
-    /// 검색 결과(photoId)를 상세 화면용 전체 Photo로 매핑하기 위한 홈 사진 색인
-    @State private var photosById: [Int: Photo] = [:]
     @Namespace private var photoZoom
     @Injected(\.homeUseCaseProvider) private var homeProvider
 
     init(provider: SearchUseCaseProviderProtocol) {
-        self._searchVM = State(initialValue: SearchViewModel(provider: provider))
+        self._searchVM = State(initialValue: SearchViewModel(
+            provider: provider,
+            getPhotosUseCase: Container.shared.homeUseCaseProvider().makeGetPhotosUseCase()
+        ))
         self._albumVM = State(initialValue: AlbumViewModel(provider: provider))
     }
 
@@ -45,9 +46,7 @@ struct SearchView: View {
         }
         .task {
             await albumVM.fetchAlbums()
-            if let photos = try? await homeProvider.makeGetPhotosUseCase().execute() {
-                photosById = Dictionary(uniqueKeysWithValues: photos.map { ($0.photoId, $0) })
-            }
+            await searchVM.loadPhotoIndex()
         }
     }
 
@@ -86,24 +85,10 @@ struct SearchView: View {
             SearchResultGrid(
                 query: searchVM.query,
                 results: searchVM.searchResults,
-                namespace: photoZoom,
-                photoResolver: photo(for:)
+                photosById: searchVM.photosById,
+                namespace: photoZoom
             )
         }
-    }
-
-    /// 홈 사진 색인에서 전체 메타데이터를 찾고, 없으면 검색 결과 정보만으로 구성
-    private func photo(for result: SearchResult) -> Photo {
-        photosById[result.photoId] ?? Photo(
-            photoId: result.photoId,
-            imageUrl: result.imageUrl,
-            latitude: 0,
-            longitude: 0,
-            createdAt: Date(),
-            fileName: "",
-            tags: [],
-            isSensitive: false
-        )
     }
 }
 
@@ -221,8 +206,8 @@ private struct AlbumCard: View {
 private struct SearchResultGrid: View {
     let query: String
     let results: [SearchResult]
+    let photosById: [Int: Photo]
     let namespace: Namespace.ID
-    let photoResolver: (SearchResult) -> Photo
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
 
@@ -235,7 +220,7 @@ private struct SearchResultGrid: View {
 
             LazyVGrid(columns: columns, spacing: 8) {
                 ForEach(results) { item in
-                    NavigationLink(value: photoResolver(item)) {
+                    NavigationLink(value: photo(for: item)) {
                         SearchResultTile(imageUrl: item.imageUrl)
                             .matchedTransitionSource(id: item.photoId, in: namespace)
                     }
@@ -245,6 +230,20 @@ private struct SearchResultGrid: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
+    }
+
+    /// 홈 사진 색인에서 전체 메타데이터를 찾고, 없으면 검색 결과 정보만으로 구성
+    private func photo(for result: SearchResult) -> Photo {
+        photosById[result.photoId] ?? Photo(
+            photoId: result.photoId,
+            imageUrl: result.imageUrl,
+            latitude: 0,
+            longitude: 0,
+            createdAt: Date(),
+            fileName: "",
+            tags: [],
+            isSensitive: false
+        )
     }
 }
 

--- a/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
@@ -7,10 +7,15 @@
 
 import SwiftUI
 import NukeUI
+import Factory
 
 struct SearchView: View {
     @State private var searchVM: SearchViewModel
     @State private var albumVM: AlbumViewModel
+    /// 검색 결과(photoId)를 상세 화면용 전체 Photo로 매핑하기 위한 홈 사진 색인
+    @State private var photosById: [Int: Photo] = [:]
+    @Namespace private var photoZoom
+    @Injected(\.homeUseCaseProvider) private var homeProvider
 
     init(provider: SearchUseCaseProviderProtocol) {
         self._searchVM = State(initialValue: SearchViewModel(provider: provider))
@@ -20,6 +25,7 @@ struct SearchView: View {
     var body: some View {
         NavigationStack {
             ScrollView { content }
+                .background(Color.base.ignoresSafeArea())
                 .navigationTitle("검색")
                 .toolbarTitleDisplayMode(.inlineLarge)
                 .searchable(text: $searchVM.query, prompt: "사진을 검색해보세요!")
@@ -31,8 +37,18 @@ struct SearchView: View {
                         searchVM.searchResults = []
                     }
                 }
+                .navigationDestination(for: Photo.self) { photo in
+                    PhotoInfoView(photo: photo, provider: homeProvider)
+                        // 홈과 동일하게 타일에서 사진이 확대되어 나오는 줌 전환
+                        .navigationTransition(.zoom(sourceID: photo.photoId, in: photoZoom))
+                }
         }
-        .task { await albumVM.fetchAlbums() }
+        .task {
+            await albumVM.fetchAlbums()
+            if let photos = try? await homeProvider.makeGetPhotosUseCase().execute() {
+                photosById = Dictionary(uniqueKeysWithValues: photos.map { ($0.photoId, $0) })
+            }
+        }
     }
 
     // MARK: - Content
@@ -49,94 +65,241 @@ struct SearchView: View {
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding()
             } else if albumVM.albums.isEmpty {
-                Text("\n앨범이 없습니다. \n같은 태그를 가진 사진을 추가해보세요!")
-                    .font(.title2)
-                    .foregroundStyle(.secondary)
-                    .bold()
+                SearchEmptyStateView(
+                    title: "아직 앨범이 없어요",
+                    subtitle: "같은 태그를 가진 사진을 추가해보세요"
+                )
             } else {
-                albumGrid
+                AlbumGridSection(
+                    albums: albumVM.albums,
+                    previews: albumVM.albumPreviews,
+                    provider: albumVM.provider,
+                    namespace: photoZoom
+                )
             }
         } else if searchVM.searchResults.isEmpty {
-            Text("검색 결과가 없습니다.")
-                .padding()
-        } else {
-            searchResultGrid
-        }
-    }
-
-    // MARK: - Album Grid
-
-    private var albumGrid: some View {
-        GeometryReader { geo in
-            let side: CGFloat = geo.size.width / 2 - 16
-            let cols = Array(repeating: GridItem(.fixed(side), spacing: 8), count: 2)
-
-            LazyVGrid(columns: cols, spacing: 8) {
-                ForEach(albumVM.albums) { album in
-                    NavigationLink {
-                        AlbumDetailView(album: album, provider: albumVM.provider)
-                    } label: {
-                        albumCell(side: side, title: album.tagName)
-                    }
-                }
-            }
-            .padding(8)
-        }
-    }
-
-    // MARK: - Search Result Grid
-
-    private var searchResultGrid: some View {
-        GeometryReader { geo in
-            let side: CGFloat = geo.size.width / 2 - 16
-            let cols = Array(repeating: GridItem(.fixed(side), spacing: 8), count: 2)
-
-            LazyVGrid(columns: cols, spacing: 8) {
-                ForEach(searchVM.searchResults) { item in
-                    resultTile(side: side, url: item.imageUrl)
-                }
-            }
-            .padding(8)
-        }
-    }
-
-    // MARK: - Components
-
-    private func albumCell(side: CGFloat, title: String) -> some View {
-        ZStack(alignment: .bottomLeading) {
-            Color.gray
-                .frame(width: side, height: side)
-            LinearGradient(
-                colors: [Color.black.opacity(0.0), Color.black.opacity(0.55)],
-                startPoint: .center,
-                endPoint: .bottom
+            SearchEmptyStateView(
+                title: "‘\(searchVM.query)’에 대한 결과가 없어요",
+                subtitle: "다른 검색어나 태그로 다시 찾아보세요"
             )
-            Text(title)
-                .font(.title2)
-                .bold()
-                .foregroundColor(.white)
-                .padding(8)
+        } else {
+            SearchResultGrid(
+                query: searchVM.query,
+                results: searchVM.searchResults,
+                namespace: photoZoom,
+                photoResolver: photo(for:)
+            )
         }
-        .frame(width: side, height: side)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// 홈 사진 색인에서 전체 메타데이터를 찾고, 없으면 검색 결과 정보만으로 구성
+    private func photo(for result: SearchResult) -> Photo {
+        photosById[result.photoId] ?? Photo(
+            photoId: result.photoId,
+            imageUrl: result.imageUrl,
+            latitude: 0,
+            longitude: 0,
+            createdAt: Date(),
+            fileName: "",
+            tags: [],
+            isSensitive: false
+        )
+    }
+}
+
+// MARK: - AlbumGridSection
+
+/// "앨범 n개" 헤더 + 2열 앨범 카드 그리드
+private struct AlbumGridSection: View {
+    let albums: [Album]
+    let previews: [Int: AlbumViewModel.AlbumPreview]
+    let provider: SearchUseCaseProviderProtocol
+    let namespace: Namespace.ID
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 2)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .firstTextBaseline, spacing: 7) {
+                Text("앨범")
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundStyle(.labelPrimary)
+                Text("\(albums.count)개")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(.labelTertiary)
+            }
+            .padding(.horizontal, 4)
+
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(albums) { album in
+                    NavigationLink {
+                        AlbumDetailView(album: album, provider: provider, namespace: namespace)
+                    } label: {
+                        AlbumCard(album: album, preview: previews[album.tagId])
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+}
+
+// MARK: - AlbumCard
+
+/// 앨범 카드 — 대표 사진 배경 + 하단 스크림 위 앨범명/장수
+private struct AlbumCard: View {
+    let album: Album
+    let preview: AlbumViewModel.AlbumPreview?
+
+    /// 대표 썸네일이 없을 때 태그별로 고정되는 배경 그라데이션 팔레트
+    private static let gradients: [(Color, Color)] = [
+        (Color(red: 0x7F / 255, green: 0xA6 / 255, blue: 0xAD / 255), Color(red: 0x4C / 255, green: 0x6E / 255, blue: 0x75 / 255)),
+        (Color(red: 0x8B / 255, green: 0xAE / 255, blue: 0x73 / 255), Color(red: 0x5A / 255, green: 0x7C / 255, blue: 0x45 / 255)),
+        (Color(red: 0x96 / 255, green: 0xA2 / 255, blue: 0xAE / 255), Color(red: 0x61 / 255, green: 0x6E / 255, blue: 0x7C / 255)),
+        (Color(red: 0xC3 / 255, green: 0x9F / 255, blue: 0x7C / 255), Color(red: 0x96 / 255, green: 0x6F / 255, blue: 0x52 / 255)),
+        (Color(red: 0xD0 / 255, green: 0xA5 / 255, blue: 0x7E / 255), Color(red: 0xA8 / 255, green: 0x7A / 255, blue: 0x54 / 255)),
+        (Color(red: 0x6E / 255, green: 0x7A / 255, blue: 0x93 / 255), Color(red: 0x45 / 255, green: 0x4E / 255, blue: 0x66 / 255)),
+    ]
+
+    private var gradient: (Color, Color) {
+        Self.gradients[abs(album.tagId) % Self.gradients.count]
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            background
+
+            LinearGradient(colors: [.clear, .black.opacity(0.4)], startPoint: .top, endPoint: .bottom)
+                .frame(height: 80)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(album.tagName)
+                    .font(.system(size: 20, weight: .bold))
+                    .tracking(-0.3)
+                    .foregroundStyle(.white)
+                if let preview {
+                    Text("\(preview.photoCount)장")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+            }
+            .padding(.leading, 16)
+            .padding(.bottom, 12)
+        }
+        .frame(height: 150)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+        .shadow(color: Color(red: 0x29 / 255, green: 0x33 / 255, blue: 0x29 / 255).opacity(0.12), radius: 7, y: 6)
     }
 
     @ViewBuilder
-    private func resultTile(side: CGFloat, url: URL) -> some View {
-        LazyImage(url: url) { state in
-            if let image = state.image {
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: side, height: side)
-                    .clipped()
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-            } else {
-                Color.gray
-                    .frame(width: side, height: side)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+    private var background: some View {
+        if let thumbnailUrl = preview?.thumbnailUrl {
+            Color.clear
+                .overlay {
+                    LazyImage(url: thumbnailUrl) { state in
+                        if let image = state.image {
+                            image
+                                .resizable()
+                                .scaledToFill()
+                        } else {
+                            LinearGradient(colors: [gradient.0, gradient.1], startPoint: .top, endPoint: .bottom)
+                        }
+                    }
+                }
+        } else {
+            LinearGradient(colors: [gradient.0, gradient.1], startPoint: .top, endPoint: .bottom)
+        }
+    }
+}
+
+// MARK: - SearchResultGrid
+
+/// "'검색어' 검색 결과 · 사진 n장" 헤더 + 3열 결과 타일 그리드
+private struct SearchResultGrid: View {
+    let query: String
+    let results: [SearchResult]
+    let namespace: Namespace.ID
+    let photoResolver: (SearchResult) -> Photo
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("‘\(query)’ 검색 결과 · 사진 \(results.count)장")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.labelSecondary)
+                .padding(.horizontal, 4)
+
+            LazyVGrid(columns: columns, spacing: 8) {
+                ForEach(results) { item in
+                    NavigationLink(value: photoResolver(item)) {
+                        SearchResultTile(imageUrl: item.imageUrl)
+                            .matchedTransitionSource(id: item.photoId, in: namespace)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+}
+
+// MARK: - SearchResultTile
+
+/// 검색 결과 정사각 썸네일 타일
+private struct SearchResultTile: View {
+    let imageUrl: URL
+
+    var body: some View {
+        Color.clear
+            .aspectRatio(1, contentMode: .fit)
+            .overlay {
+                LazyImage(url: imageUrl) { state in
+                    if let image = state.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } else {
+                        Color.gray.opacity(0.2)
+                    }
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}
+
+// MARK: - SearchEmptyStateView
+
+/// 앨범 없음/검색 결과 없음 공용 빈 상태 뷰
+private struct SearchEmptyStateView: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 36))
+                .foregroundStyle(.mainGreen)
+                .frame(width: 96, height: 96)
+                .background(.subGreen, in: Circle())
+
+            VStack(spacing: 8) {
+                Text(title)
+                    .font(.system(size: 19, weight: .bold))
+                    .foregroundStyle(.labelPrimary)
+                Text(subtitle)
+                    .font(.system(size: 14))
+                    .foregroundStyle(.labelSecondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 41)
+        .padding(.top, 160)
     }
 }
 

--- a/Rephoto_iOS/Features/Settings/Presentation/Views/SettingsView.swift
+++ b/Rephoto_iOS/Features/Settings/Presentation/Views/SettingsView.swift
@@ -8,33 +8,142 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @Binding var sheetDetent: PresentationDetent
-    @Environment(\.dismiss) private var dismiss
+    @Environment(SessionStore.self) private var session
+    @State private var showLogoutConfirmation = false
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0.0"
+    }
 
     var body: some View {
-        VStack {
-            Text("Settings")
-                .font(.largeTitle)
-            Spacer()
-        }
-        .padding()
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    sheetDetent = .medium
-                    dismiss()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
-                    }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                SettingsProfileCard(name: session.name)
+
+                Text("정보")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.labelSecondary)
+                    .padding(.leading, 12)
+                    .padding(.top, 28)
+                    .padding(.bottom, 10)
+
+                VersionRow(version: appVersion)
+
+                LogoutCard {
+                    showLogoutConfirmation = true
                 }
+                .padding(.top, 28)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+        }
+        .background(Color.base.ignoresSafeArea())
+        .navigationTitle("설정")
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog("로그아웃하시겠습니까?", isPresented: $showLogoutConfirmation, titleVisibility: .visible) {
+            Button("로그아웃", role: .destructive) {
+                Task { await session.logout() }
             }
         }
-        .tint(.black)
     }
 }
 
-#Preview {
-    SettingsView(sheetDetent: .constant(.medium))
+// MARK: - SettingsProfileCard
+
+/// 아바타(이름 첫 글자) + 이름 글래스 프로필 카드
+private struct SettingsProfileCard: View {
+    let name: String
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(name.prefix(1))
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 52, height: 52)
+                .background(
+                    LinearGradient(colors: [.lightGreen, .mainGreen], startPoint: .top, endPoint: .bottom),
+                    in: Circle()
+                )
+
+            Text(name)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.labelPrimary)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.labelTertiary)
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 16)
+        .frame(height: 80)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 18))
+    }
 }
+
+// MARK: - VersionRow
+
+/// 앱 버전 정보 글래스 행
+private struct VersionRow: View {
+    let version: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "info")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(
+                    Color(red: 0x9A / 255, green: 0xA0 / 255, blue: 0xA6 / 255),
+                    in: RoundedRectangle(cornerRadius: 8)
+                )
+
+            Text("버전")
+                .font(.system(size: 17))
+                .foregroundStyle(.labelPrimary)
+
+            Spacer()
+
+            Text(version)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.labelTertiary)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.labelTertiary)
+        }
+        .padding(.leading, 12)
+        .padding(.trailing, 16)
+        .frame(height: 54)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+// MARK: - LogoutCard
+
+/// 로그아웃 글래스 카드 버튼
+private struct LogoutCard: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("로그아웃")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(red: 0xE2 / 255, green: 0x33 / 255, blue: 0x2F / 255))
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+                .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#if DEBUG
+#Preview("Settings") {
+    NavigationStack {
+        SettingsView()
+            .environment(SessionStore(provider: MockUserUseCaseProvider()))
+    }
+}
+#endif

--- a/Rephoto_iOS/Features/Settings/Presentation/Views/SettingsView.swift
+++ b/Rephoto_iOS/Features/Settings/Presentation/Views/SettingsView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                SettingsProfileCard(name: session.name)
+                ProfileCard(name: session.name, showsChevron: true)
 
                 Text("정보")
                     .font(.system(size: 13, weight: .medium))
@@ -45,40 +45,6 @@ struct SettingsView: View {
                 Task { await session.logout() }
             }
         }
-    }
-}
-
-// MARK: - SettingsProfileCard
-
-/// 아바타(이름 첫 글자) + 이름 글래스 프로필 카드
-private struct SettingsProfileCard: View {
-    let name: String
-
-    var body: some View {
-        HStack(spacing: 14) {
-            Text(name.prefix(1))
-                .font(.system(size: 22, weight: .bold))
-                .foregroundStyle(.white)
-                .frame(width: 52, height: 52)
-                .background(
-                    LinearGradient(colors: [.lightGreen, .mainGreen], startPoint: .top, endPoint: .bottom),
-                    in: Circle()
-                )
-
-            Text(name)
-                .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(.labelPrimary)
-
-            Spacer()
-
-            Image(systemName: "chevron.right")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(.labelTertiary)
-        }
-        .padding(.leading, 14)
-        .padding(.trailing, 16)
-        .frame(height: 80)
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 18))
     }
 }
 
@@ -117,25 +83,6 @@ private struct VersionRow: View {
         .padding(.trailing, 16)
         .frame(height: 54)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16))
-    }
-}
-
-// MARK: - LogoutCard
-
-/// 로그아웃 글래스 카드 버튼
-private struct LogoutCard: View {
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text("로그아웃")
-                .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(red: 0xE2 / 255, green: 0x33 / 255, blue: 0x2F / 255))
-                .frame(maxWidth: .infinity)
-                .frame(height: 54)
-                .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
-        }
-        .buttonStyle(.plain)
     }
 }
 

--- a/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelPrimary.colorset/Contents.json
+++ b/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelPrimary.colorset/Contents.json
@@ -11,24 +11,6 @@
         }
       },
       "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x18",
-          "green" : "0x1B",
-          "red" : "0x1C"
-        }
-      },
-      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelPrimary.colorset/Contents.json
+++ b/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x18",
+          "green" : "0x1B",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x18",
+          "green" : "0x1B",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelSecondary.colorset/Contents.json
+++ b/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelSecondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x61",
+          "green" : "0x6A",
+          "red" : "0x6E"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x61",
+          "green" : "0x6A",
+          "red" : "0x6E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelSecondary.colorset/Contents.json
+++ b/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelSecondary.colorset/Contents.json
@@ -11,24 +11,6 @@
         }
       },
       "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x61",
-          "green" : "0x6A",
-          "red" : "0x6E"
-        }
-      },
-      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelTertiary.colorset/Contents.json
+++ b/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelTertiary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x9D",
+          "red" : "0xA2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x9D",
+          "red" : "0xA2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelTertiary.colorset/Contents.json
+++ b/Rephoto_iOS/Resources/Colors/Colors.xcassets/labelTertiary.colorset/Contents.json
@@ -11,24 +11,6 @@
         }
       },
       "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x93",
-          "green" : "0x9D",
-          "red" : "0xA2"
-        }
-      },
-      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rephoto_iOS/Resources/Components/GlassCards.swift
+++ b/Rephoto_iOS/Resources/Components/GlassCards.swift
@@ -1,0 +1,74 @@
+//
+//  GlassCards.swift
+//  Rephoto_iOS
+//
+//  Created by Doyeon Kim on 7/24/26.
+//
+
+import SwiftUI
+
+// MARK: - ProfileCard
+
+/// 아바타(이름 첫 글자) + 이름 글래스 프로필 카드 — 내 정보 시트/설정 화면 공용
+struct ProfileCard: View {
+    let name: String
+    var showsChevron: Bool = false
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(name.prefix(1))
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 52, height: 52)
+                .background(
+                    LinearGradient(colors: [.lightGreen, .mainGreen], startPoint: .top, endPoint: .bottom),
+                    in: Circle()
+                )
+
+            Text(name)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.labelPrimary)
+
+            Spacer()
+
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.labelTertiary)
+            }
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 16)
+        .frame(height: 80)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 18))
+    }
+}
+
+// MARK: - LogoutCard
+
+/// 로그아웃 글래스 카드 버튼 — 내 정보 시트/설정 화면 공용
+struct LogoutCard: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("로그아웃")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(red: 0xE2 / 255, green: 0x33 / 255, blue: 0x2F / 255))
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+                .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        ProfileCard(name: "김도연")
+        ProfileCard(name: "김도연", showsChevron: true)
+        LogoutCard {}
+    }
+    .padding(22)
+    .background(Color.base)
+}


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

피그마 `Rephoto — Liquid Glass` 시안 기준으로 열린 이슈(#41, #42, #43)의 UI 파트를 반영했습니다.

**HomeSheetView — 내 정보 시트 (#42)**
- placeholder List → 프로필 카드(그라데이션 아바타 + 이름) / 설정 행(아이콘 타일 + chevron) / 로그아웃 카드로 재구성
- 설정 행 push 시 시트 `.large` 확장, 복귀 시 `.medium` 복원
- 로그아웃은 confirmationDialog 확인 후 `SessionStore.logout()`

**SettingsView (#43)**
- placeholder → 프로필 카드 / 정보 섹션(버전 행, Bundle 버전 표시) / 로그아웃 카드 구현
- HomeSheetView → SettingsView 네비게이션 연결 (기존 주석 상태 해소)

**SearchView (#41 UI 파트)**
- `content`/`albumGrid` 등 computed property → 독립 View struct 분리 (`AlbumGridSection`, `AlbumCard`, `SearchResultGrid`, `SearchResultTile`, `SearchEmptyStateView`)
- `ScrollView` 안 `GeometryReader` 제거 → `GridItem(.flexible())` 교체 (앨범 진입 시 좌우 공백 글리치 원인 해결)
- 앨범 카드: 홈에 저장된 사진을 대표 썸네일로 노출 + 사진 수 표시 (`AlbumViewModel.albumPreviews`)
- 검색 결과/빈 상태 시안 반영

**AlbumDetailView**
- 콜라주 배너(대표 사진 3장 + 스크림 + 앨범 칩/제목/요약) + 3열 그리드로 재구성

**사진 상세 네비게이션 연결 (#41)**
- 검색 결과·앨범 사진 탭 시 홈과 동일한 zoom 전환(`matchedTransitionSource` + `.navigationTransition(.zoom)`)으로 `PhotoInfoView` 진입
- 검색 API가 imageUrl/photoId만 반환하므로 홈 사진 목록을 photoId로 색인해 전체 메타데이터 매핑 (미스 시 이미지 정보만으로 폴백)

**기타**
- Mock Search 데모를 홈 데모 사진(MockPhotoFixtures) 기반 앨범 6개/검색 매칭으로 재구성
- HomeView 배경 `bg/base`(#FAF6F0) 적용
- 피그마 라벨 토큰 3종 추가: `labelPrimary`(#1C1B18) / `labelSecondary`(#6E6A61) / `labelTertiary`(#A29D93)

Closes #41
Closes #42
Closes #43

## 📋 추후 진행 상황

- 포트폴리오 스크린샷 촬영 (Home / Search / PhotoInfo / Sensitive)
- 백엔드에 email(UserInfo)·앨범 대표 썸네일/장수 필드 추가되면 프로필 이메일, 앨범 카드 데이터 연결
- #41의 잔여 항목(300ms 디바운스, `searchResults` 캡슐화)은 이번 범위에서 제외하기로 함

## 📌 리뷰 포인트

- 검색 탭 → 앨범 진입 시 좌우 공백 글리치가 실제 기기에서 사라졌는지 (GeometryReader 제거로 해결 예상)
- 검색 결과 photoId를 홈 사진 색인에서 못 찾을 때의 폴백 Photo(파일명 빈 값, 좌표 0) 처리 방식이 괜찮은지
- 로그아웃 레드(#E2332F)는 에셋 심볼 생성 지연 문제로 인라인 Color로 두었음 — 추후 xcassets 이관 여부

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앨범 카드에 대표 썸네일과 사진 수를 표시합니다.
  * 앨범 상세에 콜라주 배너와 최신 정보가 포함됩니다.
  * 사진 선택 시 확대 전환 애니메이션을 적용합니다.
* **개선 사항**
  * 검색 결과/앨범 사진을 그리드 기반으로 정리하고 빈 상태 표시를 통합했습니다.
  * 로그아웃에 확인 대화상자를 추가하고 비동기 처리로 전환했습니다.
  * 설정 화면 UI를 재구성하고 앱 버전을 노출합니다.
  * 홈/검색 배경을 안전영역 기준으로 일관되게 적용했습니다.
* **기타**
  * 글래스 카드 스타일 컴포넌트를 추가하고 기본 인터페이스 스타일을 라이트로 설정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->