### PR TITLE
[Feat] 검색 300ms 디바운스 및 stale response 방지

### DIFF
--- a/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
@@ -17,6 +17,8 @@ final class SearchViewModel {
     private(set) var photosById: [Int: Photo] = [:]
     /// 색인 로드 실패 여부 — 다음 검색 시 재시도 트리거로 사용
     private var photoIndexLoadFailed = false
+    /// 요청 세대 — 상태(결과/에러/로딩) 변경을 가장 최근 요청에만 귀속시킨다
+    private var searchGeneration = 0
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     var query: String = ""
@@ -28,23 +30,28 @@ final class SearchViewModel {
 
     @MainActor
     func search(query: String) async {
+        searchGeneration += 1
+        let generation = searchGeneration
         isLoading = true
         errorMessage = nil
-        defer { isLoading = false }
 
         do {
             let results = try await provider.searchPhotos().execute(query: query)
-            // 검색어가 바뀌어 이 작업이 취소됐다면 늦게 도착한 결과로 최신 결과를 덮어쓰지 않는다
-            guard !Task.isCancelled else { return }
+            // 검색어가 바뀌어 교체/취소된 요청이면 늦게 도착한 결과로 상태를 덮어쓰지 않는다
+            guard generation == searchGeneration, !Task.isCancelled else { return }
             searchResults = results
-        } catch is CancellationError {
-            return
+            isLoading = false
         } catch {
+            // 취소는 CancellationError 외에 URLError(.cancelled) 등으로도 던져진다 —
+            // 교체/취소된 요청의 실패는 최신 요청의 상태를 건드리지 않는다
+            guard generation == searchGeneration, !Task.isCancelled, !(error is CancellationError) else { return }
             searchResults = []
             errorMessage = error.localizedDescription
+            isLoading = false
         }
 
         // 이전에 색인 로드가 실패했다면 결과 → 상세 매핑을 위해 재시도
+        // (결과 반영·로딩 종료 후에 수행 — 재시도 동안 스피너를 붙잡지 않는다)
         if photoIndexLoadFailed {
             await loadPhotoIndex()
         }
@@ -52,8 +59,10 @@ final class SearchViewModel {
 
     @MainActor
     func clearResults() {
+        searchGeneration += 1  // 진행 중 요청 무효화
         searchResults = []
         errorMessage = nil
+        isLoading = false
     }
 
     @MainActor

--- a/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/ViewModels/SearchViewModel.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 @Observable
-class SearchViewModel {
+final class SearchViewModel {
     let provider: SearchUseCaseProviderProtocol
     private let getPhotosUseCase: GetPhotosUseCaseProtocol
 
-    var searchResults: [SearchResult] = []
+    private(set) var searchResults: [SearchResult] = []
     /// 검색 결과(photoId)를 사진 상세용 전체 Photo로 매핑하기 위한 홈 사진 색인
     private(set) var photosById: [Int: Photo] = [:]
     /// 색인 로드 실패 여부 — 다음 검색 시 재시도 트리거로 사용
@@ -30,18 +30,30 @@ class SearchViewModel {
     func search(query: String) async {
         isLoading = true
         errorMessage = nil
+        defer { isLoading = false }
+
         do {
-            searchResults = try await provider.searchPhotos().execute(query: query)
+            let results = try await provider.searchPhotos().execute(query: query)
+            // 검색어가 바뀌어 이 작업이 취소됐다면 늦게 도착한 결과로 최신 결과를 덮어쓰지 않는다
+            guard !Task.isCancelled else { return }
+            searchResults = results
+        } catch is CancellationError {
+            return
         } catch {
             searchResults = []
             errorMessage = error.localizedDescription
         }
-        isLoading = false
 
         // 이전에 색인 로드가 실패했다면 결과 → 상세 매핑을 위해 재시도
         if photoIndexLoadFailed {
             await loadPhotoIndex()
         }
+    }
+
+    @MainActor
+    func clearResults() {
+        searchResults = []
+        errorMessage = nil
     }
 
     @MainActor

--- a/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
@@ -33,13 +33,13 @@ struct SearchView: View {
                 // task(id:)는 검색어가 바뀔 때마다 이전 작업을 자동 취소하므로,
                 // 300ms 대기 중 취소 = 디바운스가 됨. 대기를 통과한 마지막 검색어만 요청된다
                 .task(id: searchVM.query) {
-                    guard !searchVM.query.isEmpty else {
+                    guard !trimmedQuery.isEmpty else {
                         searchVM.clearResults()
                         return
                     }
                     try? await Task.sleep(for: .milliseconds(300))
                     guard !Task.isCancelled else { return }
-                    await searchVM.search(query: searchVM.query)
+                    await searchVM.search(query: trimmedQuery)
                 }
                 .navigationDestination(for: Photo.self) { photo in
                     PhotoInfoView(photo: photo, provider: homeProvider)
@@ -55,13 +55,18 @@ struct SearchView: View {
 
     // MARK: - Content
 
+    /// 공백만 입력한 검색어를 빈 검색어로 취급 — 분기·요청·표시가 같은 기준을 쓴다
+    private var trimmedQuery: String {
+        searchVM.query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     @ViewBuilder
     private var content: some View {
         if searchVM.isLoading {
             ProgressView("검색 중…")
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding()
-        } else if searchVM.query.isEmpty {
+        } else if trimmedQuery.isEmpty {
             if albumVM.isLoading {
                 ProgressView("앨범 불러오는 중…")
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -81,12 +86,12 @@ struct SearchView: View {
             }
         } else if searchVM.searchResults.isEmpty {
             SearchEmptyStateView(
-                title: "‘\(searchVM.query)’에 대한 결과가 없어요",
+                title: "‘\(trimmedQuery)’에 대한 결과가 없어요",
                 subtitle: "다른 검색어나 태그로 다시 찾아보세요"
             )
         } else {
             SearchResultGrid(
-                query: searchVM.query,
+                query: trimmedQuery,
                 results: searchVM.searchResults,
                 photosById: searchVM.photosById,
                 namespace: photoZoom

--- a/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
@@ -30,13 +30,16 @@ struct SearchView: View {
                 .navigationTitle("검색")
                 .toolbarTitleDisplayMode(.inlineLarge)
                 .searchable(text: $searchVM.query, prompt: "사진을 검색해보세요!")
-                .onSubmit(of: .search) {
-                    Task { await searchVM.search(query: searchVM.query) }
-                }
-                .onChange(of: searchVM.query) { _, newValue in
-                    if newValue.isEmpty {
-                        searchVM.searchResults = []
+                // task(id:)는 검색어가 바뀔 때마다 이전 작업을 자동 취소하므로,
+                // 300ms 대기 중 취소 = 디바운스가 됨. 대기를 통과한 마지막 검색어만 요청된다
+                .task(id: searchVM.query) {
+                    guard !searchVM.query.isEmpty else {
+                        searchVM.clearResults()
+                        return
                     }
+                    try? await Task.sleep(for: .milliseconds(300))
+                    guard !Task.isCancelled else { return }
+                    await searchVM.search(query: searchVM.query)
                 }
                 .navigationDestination(for: Photo.self) { photo in
                     PhotoInfoView(photo: photo, provider: homeProvider)


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

#41에서 미뤄뒀던 검색 디바운스와 상태 캡슐화를 마무리했습니다.

**검색 디바운스 (`.task(id:)` 기반 라이브 검색)**
- `.onSubmit`/`.onChange` 제거 → `.task(id: searchVM.query)` 하나로 통합
- 검색어가 바뀔 때마다 SwiftUI가 이전 task를 자동 취소하므로, `Task.sleep(300ms)` 대기 중 취소 = 디바운스. 대기를 통과한 마지막 검색어만 실제 요청됨
- Combine 없이 구현 — 프로젝트 방침(async/await 통일, Moya/Combine 제거 #46)과 일관

**stale response 방지**
- 취소는 협조적이라 이미 나간 요청의 응답이 늦게 도착할 수 있음 → 응답 반영 직전 `Task.isCancelled` 확인으로 이전 요청이 최신 결과를 덮어쓰는 레이스 차단
- `CancellationError`는 에러로 표시하지 않음, `defer { isLoading = false }`로 조기 return 경로에서도 로딩 상태 정리

**상태 캡슐화 (#41 잔여 항목)**
- `searchResults` → `private(set)`, 뷰의 직접 대입을 `clearResults()`로 대체
- `SearchViewModel` → `final class` (다른 VM과 통일)

## 📋 추후 진행 상황

- 포트폴리오 스크린샷 촬영 → 피그마 삽입 → 지원

## 📌 리뷰 포인트

- 디바운스를 VM이 아닌 `.task(id:)`(뷰 생명주기)에 둔 선택 — 이전 작업 취소·뷰 이탈 시 정리를 SwiftUI에 위임하는 가장 선언적인 형태를 택했습니다. VM의 `search()`는 여전히 단독 테스트 가능
- 라이브 검색 전환으로 제출(엔터) 없이도 검색됩니다 — 기존 onSubmit 제거가 UX상 괜찮은지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 검색어 입력 후 300ms 동안 입력이 멈추면 자동으로 검색하도록 개선했습니다.
  * 새로운 검색어를 입력하면 이전 검색 작업이 자동으로 취소되어 오래된 결과가 표시되지 않습니다.
  * 검색어를 모두 지우면 검색 결과와 오류 메시지가 즉시 초기화됩니다.

* **버그 수정**
  * 검색 중 오류나 취소가 발생해도 로딩 상태가 안정적으로 종료되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->