### PR TITLE
[Fix] 전 화면 배경 Color.base 통일 및 TabBar 틴트 mainGreen 적용

### DIFF
--- a/Rephoto_iOS/Features/Home/Presentation/Views/Components/TagEditorSheet.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/Components/TagEditorSheet.swift
@@ -78,6 +78,7 @@ struct TagEditorSheet: View {
                 Spacer()
             }
             .padding(20)
+            .background(Color.base.ignoresSafeArea())
             .navigationTitle(mode.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Rephoto_iOS/Features/Home/Presentation/Views/PhotoInfoView.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/PhotoInfoView.swift
@@ -51,6 +51,7 @@ struct PhotoInfoView: View {
             .padding(.bottom, 32)
         }
         .scrollIndicators(.hidden)
+        .background(Color.base.ignoresSafeArea())
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/Rephoto_iOS/Features/Home/Presentation/Views/SensitivePhotosView.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/SensitivePhotosView.swift
@@ -36,6 +36,7 @@ struct SensitivePhotosView: View {
                 }
             }
         }
+        .background(Color.base.ignoresSafeArea())
         .navigationTitle("민감한 사진")
         .navigationBarTitleDisplayMode(.inline)
         .safeAreaInset(edge: .bottom) {

--- a/Rephoto_iOS/Features/RephotoTabView.swift
+++ b/Rephoto_iOS/Features/RephotoTabView.swift
@@ -23,7 +23,7 @@ struct RephotoTabView: View {
                 SearchView(provider: searchProvider)
             }
         }
-        .tint(.green)
+        .tint(.mainGreen)
         .tabBarMinimizeBehavior(.onScrollDown)
         // 하위 탭(프로필/로그아웃 UI 등)이 @Environment(SessionStore.self)로 세션에 접근
         .environment(session)


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
- 배경 지정이 누락되어 시스템 기본 배경(흰색)으로 보이던 화면에 `Color.base` 배경 추가
  - `PhotoInfoView` (사진 상세)
  - `SensitivePhotosView` (민감한 사진)
  - `TagEditorSheet` (태그 추가/수정 시트)
- `RephotoTabView`의 TabBar 틴트를 시스템 `.green` → 브랜드 컬러 `.mainGreen`으로 수정

이로써 홈·검색/앨범·앨범 상세·설정·사진 상세·민감한 사진·시트까지 모든 화면 배경이 `Color.base`로 통일됩니다.

## 📋 추후 진행 상황
- 포트폴리오용 스크린샷 촬영 및 피그마 정리

## 📌 리뷰 포인트
- 각 화면 진입 시 배경이 `Color.base`로 일관되게 보이는지
- TabBar 선택 색상이 `mainGreen`으로 적용됐는지

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 태그 편집 시트, 사진 정보 및 민감한 사진 화면의 배경이 전체 화면에 일관되게 표시됩니다.
  * 탭 바의 강조 색상이 새로운 메인 그린 색상으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->