### PR TITLE
[Test] 테스트 인프라 정리 — CI 테스트 실행·커버리지, 플랜 분리, APITarget 계약 테스트

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     runs-on: macos-26
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -38,3 +38,25 @@ jobs:
             -configuration Debug \
             -clonedSourcePackagesDirPath .spm-cache \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -project Rephoto_iOS.xcodeproj \
+            -scheme Rephoto_iOS \
+            -testPlan Rephoto_iOS \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -configuration Debug \
+            -clonedSourcePackagesDirPath .spm-cache \
+            -resultBundlePath TestResults.xcresult \
+            -enableCodeCoverage YES
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ -d TestResults.xcresult ]; then
+            echo '## Code Coverage' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            xcrun xccov view --report --only-targets TestResults.xcresult >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -29,25 +29,28 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
-      - name: Build
+      # 앱과 테스트 번들을 한 번만 빌드한다.
+      # xcodebuild build는 테스트 타겟을 만들지 않아, 뒤이은 test가 처음부터 다시 빌드했다.
+      # 커버리지 계측은 빌드 시점 설정이라 이 스텝에도 -enableCodeCoverage가 필요하다.
+      - name: Build for testing
         run: |
-          xcodebuild build \
-            -project Rephoto_iOS.xcodeproj \
-            -scheme Rephoto_iOS \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
-            -configuration Debug \
-            -clonedSourcePackagesDirPath .spm-cache \
-            CODE_SIGNING_ALLOWED=NO
-
-      - name: Test
-        run: |
-          xcodebuild test \
+          xcodebuild build-for-testing \
             -project Rephoto_iOS.xcodeproj \
             -scheme Rephoto_iOS \
             -testPlan Rephoto_iOS \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -configuration Debug \
             -clonedSourcePackagesDirPath .spm-cache \
+            -enableCodeCoverage YES
+
+      - name: Test
+        run: |
+          xcodebuild test-without-building \
+            -project Rephoto_iOS.xcodeproj \
+            -scheme Rephoto_iOS \
+            -testPlan Rephoto_iOS \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -configuration Debug \
             -resultBundlePath TestResults.xcresult \
             -enableCodeCoverage YES
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ xcuserdata/
 ## Obj-C/Swift specific
 *.hmap
 
+## 테스트 결과 번들 (CI 산출물)
+TestResults.xcresult/
+
 # ignore xcconfig
 *.xcconfig
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ Rephoto_iOS/
 
 ## CI
 
-- `main` 브랜치 push / PR 시 GitHub Actions가 자동 빌드 검증을 수행합니다.
+- `main` 브랜치 push / PR 시 GitHub Actions가 빌드와 단위 테스트를 검증합니다.
 - 실행 환경: `macos-26`, `iPhone 17 Pro` 시뮬레이터
+- 테스트 플랜을 분리해 단위 테스트만 PR 게이트로 실행하고,
+  머신 편차가 큰 성능 벤치마크는 수동 실행합니다. (`Rephoto_iOSTests/TESTING.md`)
+- 코드 커버리지는 `xccov` 리포트로 Actions 요약에 출력됩니다.
 - SPM 캐시 적용으로 빌드 시간을 단축하고, 동일 브랜치 중복 실행은 자동 취소합니다.
 
 <br>

--- a/Rephoto_Performance.xctestplan
+++ b/Rephoto_Performance.xctestplan
@@ -1,15 +1,15 @@
 {
   "configurations" : [
     {
-      "id" : "70BCBDBC-3BE0-410D-AA1E-E14C6AADB199",
-      "name" : "Test Scheme Action",
+      "id" : "D863D323-59D8-4FC0-A3BB-3C6198F75E91",
+      "name" : "Performance",
       "options" : {
 
       }
     }
   ],
   "defaultOptions" : {
-    "performanceAntipatternCheckerEnabled" : false,
+    "performanceAntipatternCheckerEnabled" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:Rephoto_iOS.xcodeproj",
       "identifier" : "0BE71D512E1657D500E85407",
@@ -19,7 +19,7 @@
   "testTargets" : [
     {
       "parallelizable" : false,
-      "skippedTests" : [
+      "selectedTests" : [
         "DecodingPerformanceTests",
         "HomeDerivedCollectionPerformanceTests",
         "MappingPerformanceTests",

--- a/Rephoto_iOS.xcodeproj/xcshareddata/xcschemes/Rephoto_iOS.xcscheme
+++ b/Rephoto_iOS.xcodeproj/xcshareddata/xcschemes/Rephoto_iOS.xcscheme
@@ -33,6 +33,9 @@
             reference = "container:Rephoto_iOS.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Rephoto_Performance.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/Rephoto_iOS/Core/NetworkAdapter/NetworkClient/NetworkClient.swift
+++ b/Rephoto_iOS/Core/NetworkAdapter/NetworkClient/NetworkClient.swift
@@ -102,9 +102,11 @@ extension NetworkClient {
                 throw NetworkError.unauthorized
             }
 
+            // 재시도 호출은 do 블록 밖에 둔다.
+            // 안에 두면 재귀 호출이 한도 초과로 던진 unauthorized까지 아래 catch에 걸려
+            // onRefreshFailed가 호출 깊이만큼 중복 실행된다.
             do {
                 _ = try await refreshToken()
-                return try await performRequest(urlRequest, retryCount: retryCount + 1)
             } catch is NetworkError {
                 onRefreshFailed?()
                 throw NetworkError.unauthorized
@@ -114,6 +116,8 @@ extension NetworkClient {
             } catch {
                 throw error
             }
+
+            return try await performRequest(urlRequest, retryCount: retryCount + 1)
         }
 
         // 성공 응답 확인

--- a/Rephoto_iOS/Core/NetworkAdapter/NetworkClient/NetworkClient.swift
+++ b/Rephoto_iOS/Core/NetworkAdapter/NetworkClient/NetworkClient.swift
@@ -25,6 +25,8 @@ actor NetworkClient {
 
     /// 리프레시 실패 시 호출되는 콜백 (예: 강제 로그아웃)
     private var onRefreshFailed: (@Sendable () -> Void)?
+    /// 세션 종료 통지를 이미 보냈는지 여부. 새 토큰을 확보하면 다시 false가 된다.
+    private var hasNotifiedRefreshFailure = false
 
     // MARK: - Initializer
 
@@ -59,6 +61,7 @@ actor NetworkClient {
     /// 토큰 저장 (로그인 성공 후 호출)
     func saveTokens(accessToken: String, refreshToken: String) async throws {
         try await tokenStore.save(accessToken: accessToken, refreshToken: refreshToken)
+        hasNotifiedRefreshFailure = false
     }
 
     /// 로그인 여부 확인
@@ -98,20 +101,20 @@ extension NetworkClient {
         // 401 에러 응답 처리
         if authPolicy.isUnauthorizedResponse(httpResponse) {
             guard retryCount < maxRetryCount else {
-                onRefreshFailed?()
+                notifyRefreshFailed()
                 throw NetworkError.unauthorized
             }
 
             // 재시도 호출은 do 블록 밖에 둔다.
             // 안에 두면 재귀 호출이 한도 초과로 던진 unauthorized까지 아래 catch에 걸려
-            // onRefreshFailed가 호출 깊이만큼 중복 실행된다.
+            // 세션 종료 처리 경로를 한 번 더 타게 된다.
             do {
                 _ = try await refreshToken()
             } catch is NetworkError {
-                onRefreshFailed?()
+                notifyRefreshFailed()
                 throw NetworkError.unauthorized
             } catch is TokenRefreshError {
-                onRefreshFailed?()
+                notifyRefreshFailed()
                 throw NetworkError.unauthorized
             } catch {
                 throw error
@@ -126,6 +129,17 @@ extension NetworkClient {
         }
 
         return (data, httpResponse)
+    }
+
+    /// 세션 종료를 상위에 통지한다. 새 토큰을 확보하기 전까지 1회만 나간다.
+    ///
+    /// 갱신 Task는 하나로 합쳐지지만 그 실패는 대기하던 요청 전원에게 전달된다.
+    /// 각자 콜백을 부르면 동시 401 N건에 통지가 N번 나가므로, 여기서 한 번으로 접는다.
+    /// 재귀 재시도와 재시도 한도 소진 경로도 같은 이유로 이 함수를 거친다.
+    private func notifyRefreshFailed() {
+        guard !hasNotifiedRefreshFailure else { return }
+        hasNotifiedRefreshFailure = true
+        onRefreshFailed?()
     }
 
     /// 토큰 갱신 수행 (Task deduplication으로 중복 방지)
@@ -149,6 +163,8 @@ extension NetworkClient {
                 accessToken: tokenPair.accessToken,
                 refreshToken: tokenPair.refreshToken
             )
+            // 세션이 되살아났으므로 다음 만료 때 다시 통지할 수 있게 되돌린다.
+            hasNotifiedRefreshFailure = false
 
             return tokenPair
         }

--- a/Rephoto_iOSTests/Features/Home/Data/DescriptionAPITargetTests.swift
+++ b/Rephoto_iOSTests/Features/Home/Data/DescriptionAPITargetTests.swift
@@ -1,0 +1,29 @@
+//
+//  DescriptionAPITargetTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 8/2/26.
+//
+
+import Foundation
+import Testing
+@testable import Rephoto_iOS
+
+/// DescriptionAPITarget의 엔드포인트 계약 검증.
+@Suite("DescriptionAPITarget — 엔드포인트 계약")
+struct DescriptionAPITargetTests {
+
+    @Test("getDescription — photoId가 path에 보간된다", arguments: [1, 42, 9999])
+    func getDescription(photoId: Int) {
+        let target = DescriptionAPITarget.getDescription(photoId: photoId)
+
+        #expect(target.path == "/photos/\(photoId)/description")
+        #expect(target.method == .get)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("getDescription — JSON 기본 헤더를 사용한다")
+    func getDescriptionUsesJSONHeader() {
+        #expect(DescriptionAPITarget.getDescription(photoId: 1).headers == ["Content-Type": "application/json"])
+    }
+}

--- a/Rephoto_iOSTests/Features/Home/Data/PhotosAPITargetTests.swift
+++ b/Rephoto_iOSTests/Features/Home/Data/PhotosAPITargetTests.swift
@@ -1,0 +1,112 @@
+//
+//  PhotosAPITargetTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 8/2/26.
+//
+
+import Foundation
+import Testing
+@testable import Rephoto_iOS
+
+/// PhotosAPITarget의 엔드포인트 계약 검증.
+///
+/// 서버 스펙(path/method/바디 구성)이 바뀌면 컴파일은 통과해도 런타임에서만 깨지므로,
+/// 순수 함수인 target 선언 자체를 값으로 고정해 스펙 변경의 1차 방어선을 만든다.
+@Suite("PhotosAPITarget — 엔드포인트 계약")
+struct PhotosAPITargetTests {
+
+    // MARK: - path / method
+
+    @Test("getAllPhotos — GET /photos")
+    func getAllPhotos() {
+        let target = PhotosAPITarget.getAllPhotos
+
+        #expect(target.path == "/photos")
+        #expect(target.method == .get)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("deletePhoto — photoId가 path에 보간된다", arguments: [1, 42, 9999])
+    func deletePhoto(photoId: Int) {
+        let target = PhotosAPITarget.deletePhoto(photoId: photoId)
+
+        #expect(target.path == "/photos/\(photoId)")
+        #expect(target.method == .delete)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("s3Upload — POST /photos/s3")
+    func s3UploadPathAndMethod() {
+        let target = PhotosAPITarget.s3Upload(file: Data("img".utf8))
+
+        #expect(target.path == "/photos/s3")
+        #expect(target.method == .post)
+    }
+
+    @Test("savePhotosBatch — POST /photos/batch")
+    func savePhotosBatchPathAndMethod() {
+        let target = PhotosAPITarget.savePhotosBatch(request: PhotoBatchRequestDTO(photos: []))
+
+        #expect(target.path == "/photos/batch")
+        #expect(target.method == .post)
+    }
+
+    // MARK: - task
+
+    /// 파일 파트 이름·파일명·MIME은 서버가 파싱 기준으로 삼는 값이라 함께 고정한다.
+    @Test("s3Upload — file 파트 하나로 multipart를 구성하고 원본 바이트를 보존한다")
+    func s3UploadBuildsMultipart() throws {
+        // JPEG 헤더 유사 바이트 — UTF-8로 디코딩 불가한 바이너리
+        let fileData = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10])
+        let target = PhotosAPITarget.s3Upload(file: fileData)
+
+        let items = try #require(target.task.multipartItems, "task가 .multipart가 아님")
+        #expect(items.count == 1)
+        #expect(items[0].name == "file")
+        #expect(items[0].fileName == "photo.jpg")
+        #expect(items[0].mimeType == "image/jpeg")
+        #expect(items[0].data == fileData)
+    }
+
+    @Test("savePhotosBatch — 메타데이터 배열을 그대로 JSON 바디에 싣는다")
+    func savePhotosBatchCarriesMetadata() throws {
+        let metadata = PhotoMetadataDTO(
+            latitude: 33.4507,
+            longitude: 126.5706,
+            imageUrl: "https://cdn.test/jeju.jpg",
+            createdAt: "2026-08-02T09:30:00Z",
+            fileName: "jeju.jpg"
+        )
+        let target = PhotosAPITarget.savePhotosBatch(request: PhotoBatchRequestDTO(photos: [metadata]))
+
+        let body = try #require(target.task.jsonBody(as: PhotoBatchRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.photos.count == 1)
+        #expect(body.photos[0].latitude == 33.4507)
+        #expect(body.photos[0].longitude == 126.5706)
+        #expect(body.photos[0].imageUrl == "https://cdn.test/jeju.jpg")
+        #expect(body.photos[0].createdAt == "2026-08-02T09:30:00Z")
+        #expect(body.photos[0].fileName == "jeju.jpg")
+    }
+
+    // MARK: - headers
+
+    /// s3Upload만 헤더를 nil로 내려 NetworkAdapter가 boundary 포함 Content-Type을 설정하게 위임한다.
+    @Test("s3Upload — Content-Type을 타겟에서 지정하지 않는다")
+    func s3UploadOmitsContentTypeHeader() {
+        #expect(PhotosAPITarget.s3Upload(file: Data()).headers == nil)
+    }
+
+    @Test("multipart가 아닌 케이스는 JSON 기본 헤더를 유지한다")
+    func nonMultipartCasesUseJSONHeader() {
+        let targets: [PhotosAPITarget] = [
+            .getAllPhotos,
+            .deletePhoto(photoId: 1),
+            .savePhotosBatch(request: PhotoBatchRequestDTO(photos: []))
+        ]
+
+        for target in targets {
+            #expect(target.headers == ["Content-Type": "application/json"])
+        }
+    }
+}

--- a/Rephoto_iOSTests/Features/Home/Data/TagAPITargetTests.swift
+++ b/Rephoto_iOSTests/Features/Home/Data/TagAPITargetTests.swift
@@ -1,0 +1,96 @@
+//
+//  TagAPITargetTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 8/2/26.
+//
+
+import Foundation
+import Testing
+@testable import Rephoto_iOS
+
+/// TagAPITarget의 엔드포인트 계약 검증.
+///
+/// 태그는 조회만 사진 하위 경로(`/photos/{id}/tags`)를 쓰고 생성·수정·삭제는 `/tags` 계열을 쓴다.
+/// 두 경로 체계가 섞여 있어 오타가 나기 쉬운 지점이라 케이스별로 고정한다.
+@Suite("TagAPITarget — 엔드포인트 계약")
+struct TagAPITargetTests {
+
+    // MARK: - path / method
+
+    @Test("getTags — photoId가 사진 하위 경로에 보간된다", arguments: [1, 42, 9999])
+    func getTags(photoId: Int) {
+        let target = TagAPITarget.getTags(photoId: photoId)
+
+        #expect(target.path == "/photos/\(photoId)/tags")
+        #expect(target.method == .get)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("addTag — POST /tags")
+    func addTagPathAndMethod() {
+        let target = TagAPITarget.addTag(request: AddTagRequestDTO(photoId: 1, tagName: "바다"))
+
+        #expect(target.path == "/tags")
+        #expect(target.method == .post)
+    }
+
+    @Test("updateTag — photoTagId가 path에 보간된다", arguments: [1, 42, 9999])
+    func updateTag(photoTagId: Int) {
+        let target = TagAPITarget.updateTag(
+            photoTagId: photoTagId,
+            request: UpdateTagRequestDTO(tagName: "노을")
+        )
+
+        #expect(target.path == "/tags/\(photoTagId)")
+        #expect(target.method == .put)
+    }
+
+    @Test("deleteTag — photoTagId가 path에 보간된다", arguments: [1, 42, 9999])
+    func deleteTag(photoTagId: Int) {
+        let target = TagAPITarget.deleteTag(photoTagId: photoTagId)
+
+        #expect(target.path == "/tags/\(photoTagId)")
+        #expect(target.method == .delete)
+        #expect(target.task.isPlain)
+    }
+
+    // MARK: - task
+
+    @Test("addTag — photoId와 tagName을 JSON 바디로 싣는다")
+    func addTagCarriesPhotoIdAndTagName() throws {
+        let target = TagAPITarget.addTag(request: AddTagRequestDTO(photoId: 7, tagName: "바다"))
+
+        let body = try #require(target.task.jsonBody(as: AddTagRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.photoId == 7)
+        #expect(body.tagName == "바다")
+    }
+
+    /// updateTag의 식별자는 path로만 전달된다 — 바디에는 tagName만 실린다.
+    @Test("updateTag — 바디에는 tagName만 싣고 식별자는 path로 전달한다")
+    func updateTagCarriesOnlyTagName() throws {
+        let target = TagAPITarget.updateTag(
+            photoTagId: 7,
+            request: UpdateTagRequestDTO(tagName: "노을")
+        )
+
+        let body = try #require(target.task.jsonBody(as: UpdateTagRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.tagName == "노을")
+    }
+
+    // MARK: - headers
+
+    @Test("모든 케이스가 JSON 기본 헤더를 사용한다")
+    func allCasesUseJSONHeader() {
+        let targets: [TagAPITarget] = [
+            .getTags(photoId: 1),
+            .addTag(request: AddTagRequestDTO(photoId: 1, tagName: "바다")),
+            .updateTag(photoTagId: 1, request: UpdateTagRequestDTO(tagName: "노을")),
+            .deleteTag(photoTagId: 1)
+        ]
+
+        for target in targets {
+            #expect(target.headers == ["Content-Type": "application/json"])
+        }
+    }
+}

--- a/Rephoto_iOSTests/Features/Search/Data/AlbumAPITargetTests.swift
+++ b/Rephoto_iOSTests/Features/Search/Data/AlbumAPITargetTests.swift
@@ -1,0 +1,45 @@
+//
+//  AlbumAPITargetTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 8/2/26.
+//
+
+import Foundation
+import Testing
+@testable import Rephoto_iOS
+
+/// AlbumAPITarget의 엔드포인트 계약 검증.
+///
+/// 앨범 상세는 앨범 자체가 아니라 사진 목록을 반환하므로 경로가 `/albums/{tagId}/photos`로 끝난다.
+/// 또한 경로 파라미터가 albumId가 아니라 tagId라는 점을 함께 고정한다.
+@Suite("AlbumAPITarget — 엔드포인트 계약")
+struct AlbumAPITargetTests {
+
+    @Test("getAlbumList — GET /albums")
+    func getAlbumList() {
+        let target = AlbumAPITarget.getAlbumList
+
+        #expect(target.path == "/albums")
+        #expect(target.method == .get)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("getAlbumInfo — tagId가 path에 보간되고 /photos로 끝난다", arguments: [1, 42, 9999])
+    func getAlbumInfo(tagId: Int) {
+        let target = AlbumAPITarget.getAlbumInfo(tagId: tagId)
+
+        #expect(target.path == "/albums/\(tagId)/photos")
+        #expect(target.method == .get)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("모든 케이스가 JSON 기본 헤더를 사용한다")
+    func allCasesUseJSONHeader() {
+        let targets: [AlbumAPITarget] = [.getAlbumList, .getAlbumInfo(tagId: 1)]
+
+        for target in targets {
+            #expect(target.headers == ["Content-Type": "application/json"])
+        }
+    }
+}

--- a/Rephoto_iOSTests/Features/Search/Data/SearchAPITargetTests.swift
+++ b/Rephoto_iOSTests/Features/Search/Data/SearchAPITargetTests.swift
@@ -1,0 +1,48 @@
+//
+//  SearchAPITargetTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 8/2/26.
+//
+
+import Foundation
+import Testing
+@testable import Rephoto_iOS
+
+/// SearchAPITarget의 엔드포인트 계약 검증.
+///
+/// 검색은 자연어 질의를 URL이 아닌 JSON 바디로 보낸다 — 길이 제한과 인코딩 이슈를 피하기 위함.
+/// 쿼리스트링으로 되돌아가지 않도록 POST + 바디 구성을 함께 고정한다.
+@Suite("SearchAPITarget — 엔드포인트 계약")
+struct SearchAPITargetTests {
+
+    @Test("search — POST /search")
+    func searchPathAndMethod() {
+        let target = SearchAPITarget.search(query: "제주도 바다")
+
+        #expect(target.path == "/search")
+        #expect(target.method == .post)
+    }
+
+    @Test(
+        "search — query를 SearchRequestDTO 바디로 감싼다",
+        arguments: ["제주도 바다", "노을 지는 하늘", "cafe & 디저트"]
+    )
+    func searchWrapsQueryInBody(query: String) throws {
+        let target = SearchAPITarget.search(query: query)
+
+        let body = try #require(target.task.jsonBody(as: SearchRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.query == query)
+    }
+
+    /// 질의어는 path에 섞이지 않아야 한다 — 공백/특수문자 인코딩 사고를 막는 계약.
+    @Test("search — query가 path에 섞이지 않는다")
+    func searchKeepsQueryOutOfPath() {
+        #expect(SearchAPITarget.search(query: "cafe & 디저트").path == "/search")
+    }
+
+    @Test("search — JSON 기본 헤더를 사용한다")
+    func searchUsesJSONHeader() {
+        #expect(SearchAPITarget.search(query: "바다").headers == ["Content-Type": "application/json"])
+    }
+}

--- a/Rephoto_iOSTests/Features/User/Data/UserAPITargetTests.swift
+++ b/Rephoto_iOSTests/Features/User/Data/UserAPITargetTests.swift
@@ -1,0 +1,152 @@
+//
+//  UserAPITargetTests.swift
+//  Rephoto_iOSTests
+//
+//  Created by Doyeon Kim on 8/2/26.
+//
+
+import Foundation
+import Testing
+@testable import Rephoto_iOS
+
+/// UserAPITarget의 엔드포인트 계약 검증.
+///
+/// 조회·수정·삭제가 `/users` 하나를 method로만 구분하므로, path만으로는 오설정을 잡을 수 없다.
+/// 또 `/login` `/join` `/auth/refresh`는 DefaultAuthenticationPolicy가 공개 경로로 판정하는 값이라,
+/// 여기서 path가 바뀌면 토큰 주입 여부까지 함께 틀어진다.
+@Suite("UserAPITarget — 엔드포인트 계약")
+struct UserAPITargetTests {
+
+    // MARK: - path / method
+
+    @Test("join — POST /join")
+    func join() {
+        let target = UserAPITarget.join(loginId: "dodle", password: "secret!", username: "도연")
+
+        #expect(target.path == "/join")
+        #expect(target.method == .post)
+    }
+
+    @Test("login — POST /login")
+    func login() {
+        let target = UserAPITarget.login(loginId: "dodle", password: "secret!")
+
+        #expect(target.path == "/login")
+        #expect(target.method == .post)
+    }
+
+    @Test("logout — POST /logout, 바디 없음")
+    func logout() {
+        let target = UserAPITarget.logout
+
+        #expect(target.path == "/logout")
+        #expect(target.method == .post)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("refreshToken — POST /auth/refresh")
+    func refreshTokenPathAndMethod() {
+        let target = UserAPITarget.refreshToken(refreshToken: "refresh-token-value")
+
+        #expect(target.path == "/auth/refresh")
+        #expect(target.method == .post)
+    }
+
+    /// `/users`는 세 케이스가 공유하므로 method가 유일한 구분자다.
+    @Test("getUser — GET /users")
+    func getUser() {
+        let target = UserAPITarget.getUser
+
+        #expect(target.path == "/users")
+        #expect(target.method == .get)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("updateUser — PUT /users")
+    func updateUser() {
+        let target = UserAPITarget.updateUser(username: "도연", password: "new-secret!")
+
+        #expect(target.path == "/users")
+        #expect(target.method == .put)
+    }
+
+    @Test("deleteUser — DELETE /users")
+    func deleteUser() {
+        let target = UserAPITarget.deleteUser
+
+        #expect(target.path == "/users")
+        #expect(target.method == .delete)
+        #expect(target.task.isPlain)
+    }
+
+    @Test("/users를 공유하는 세 케이스는 method로만 구분된다")
+    func usersPathIsDisambiguatedByMethodOnly() {
+        let methods = [UserAPITarget.getUser, .updateUser(username: "도연", password: "pw"), .deleteUser]
+            .map(\.method)
+
+        #expect(Set(methods) == [.get, .put, .delete])
+    }
+
+    // MARK: - task
+
+    @Test("join — 가입 정보 3개를 JSON 바디로 싣는다")
+    func joinCarriesCredentials() throws {
+        let target = UserAPITarget.join(loginId: "dodle", password: "secret!", username: "도연")
+
+        let body = try #require(target.task.jsonBody(as: JoinRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.loginId == "dodle")
+        #expect(body.password == "secret!")
+        #expect(body.username == "도연")
+    }
+
+    @Test("login — 자격증명을 JSON 바디로 싣는다")
+    func loginCarriesCredentials() throws {
+        let target = UserAPITarget.login(loginId: "dodle", password: "secret!")
+
+        let body = try #require(target.task.jsonBody(as: LoginRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.loginId == "dodle")
+        #expect(body.password == "secret!")
+    }
+
+    @Test("updateUser — username/password를 JSON 바디로 싣는다")
+    func updateUserCarriesFields() throws {
+        let target = UserAPITarget.updateUser(username: "도연", password: "new-secret!")
+
+        let body = try #require(target.task.jsonBody(as: UpdateUserRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.username == "도연")
+        #expect(body.password == "new-secret!")
+    }
+
+    /// RefreshTokenRequestDTO는 CodingKeys로 서버가 기대하는 "Authorization" 필드명에 매핑된다.
+    /// 이 키가 틀어지면 갱신이 조용히 실패하고 전 화면이 강제 로그아웃되므로 인코딩 결과까지 검증한다.
+    @Test("refreshToken — 바디를 Authorization 키로 인코딩한다")
+    func refreshTokenUsesAuthorizationBodyKey() throws {
+        let target = UserAPITarget.refreshToken(refreshToken: "refresh-token-value")
+
+        let body = try #require(target.task.jsonBody(as: RefreshTokenRequestDTO.self), "task가 .jsonEncodable이 아님")
+        #expect(body.refreshToken == "refresh-token-value")
+
+        let encoded = try JSONEncoder().encode(body)
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? NSDictionary)
+        #expect(json == ["Authorization": "refresh-token-value"])
+    }
+
+    // MARK: - headers
+
+    @Test("모든 케이스가 JSON 기본 헤더를 사용한다")
+    func allCasesUseJSONHeader() {
+        let targets: [UserAPITarget] = [
+            .join(loginId: "dodle", password: "pw", username: "도연"),
+            .login(loginId: "dodle", password: "pw"),
+            .updateUser(username: "도연", password: "pw"),
+            .getUser,
+            .deleteUser,
+            .logout,
+            .refreshToken(refreshToken: "refresh-token-value")
+        ]
+
+        for target in targets {
+            #expect(target.headers == ["Content-Type": "application/json"])
+        }
+    }
+}

--- a/Rephoto_iOSTests/Network/NetworkClientTests.swift
+++ b/Rephoto_iOSTests/Network/NetworkClientTests.swift
@@ -198,7 +198,7 @@ extension StubURLProtocolSuites {
             StubURLProtocol.handler = { req in (Self.response(req.url, 401), Data("{}".utf8)) }
 
             let counter = CallCounter()
-            await client.setOnRefreshFailed { Task { await counter.increment() } }
+            await client.setOnRefreshFailed { counter.increment() }
 
             let req = request(path: "/photos")
             await withTaskGroup(of: Void.self) { group in
@@ -207,11 +207,8 @@ extension StubURLProtocolSuites {
                 }
             }
 
-            // 콜백이 Task로 감싸여 있으므로 카운트가 반영될 여지를 준다.
-            try await Task.sleep(for: .milliseconds(100))
-
-            let notifyCount = await counter.value()
-            #expect(notifyCount == 1, "동시 401 20건이 같은 갱신 실패를 공유해도 통지는 1회여야 한다")
+            // 통지는 요청이 throw하기 전에 동기로 끝나므로, 그룹이 끝난 시점에 카운트는 확정이다.
+            #expect(counter.value == 1, "동시 401 20건이 같은 갱신 실패를 공유해도 통지는 1회여야 한다")
             let refreshCount = await refresh.count()
             #expect(refreshCount == 1, "갱신 시도 자체도 1회여야 한다")
         }
@@ -227,7 +224,7 @@ extension StubURLProtocolSuites {
             let client = makeClient(tokenStore: store, refreshService: refresh)
 
             let counter = CallCounter()
-            await client.setOnRefreshFailed { Task { await counter.increment() } }
+            await client.setOnRefreshFailed { counter.increment() }
 
             // 1라운드: 401 → 갱신 성공 → 재시도 성공. 통지 없음.
             StubURLProtocol.handler = { req in
@@ -236,9 +233,7 @@ extension StubURLProtocolSuites {
             }
             _ = try await client.request(request(path: "/photos"))
 
-            try await Task.sleep(for: .milliseconds(50))
-            let afterRecovery = await counter.value()
-            #expect(afterRecovery == 0, "갱신이 성공했으면 통지는 없어야 한다")
+            #expect(counter.value == 0, "갱신이 성공했으면 통지는 없어야 한다")
 
             // 2라운드: 다시 401 → 이번엔 갱신 실패 → 통지가 나가야 한다.
             StubURLProtocol.handler = { req in (Self.response(req.url, 401), Data("{}".utf8)) }
@@ -246,9 +241,7 @@ extension StubURLProtocolSuites {
                 _ = try await client.request(self.request(path: "/photos"))
             }
 
-            try await Task.sleep(for: .milliseconds(50))
-            let afterFailure = await counter.value()
-            #expect(afterFailure == 1, "세션이 되살아난 뒤의 갱신 실패는 다시 통지돼야 한다")
+            #expect(counter.value == 1, "세션이 되살아난 뒤의 갱신 실패는 다시 통지돼야 한다")
         }
 
         // MARK: - logout
@@ -314,10 +307,15 @@ actor ScriptedRefreshService: TokenRefreshService {
 }
 
 /// onRefreshFailed 호출 횟수를 세는 카운터.
-/// 콜백이 @Sendable 클로저라 actor로 감싸 경합 없이 집계한다.
-actor CallCounter {
+///
+/// actor가 아니라 락으로 감싼다. 콜백이 동기 클로저(`@Sendable () -> Void`)라
+/// actor로 만들면 `Task { await ... }`로 넘겨야 하고, 그러면 집계 시점이 밀려
+/// 검증 전에 sleep으로 기다리는 비결정적 테스트가 된다.
+/// 락 기반이면 콜백 호출 즉시 집계되므로, 요청이 끝난 시점에 카운트가 확정된다.
+final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
     private var count = 0
 
-    func increment() { count += 1 }
-    func value() -> Int { count }
+    func increment() { lock.withLock { count += 1 } }
+    var value: Int { lock.withLock { count } }
 }

--- a/Rephoto_iOSTests/Network/NetworkClientTests.swift
+++ b/Rephoto_iOSTests/Network/NetworkClientTests.swift
@@ -188,6 +188,69 @@ extension StubURLProtocolSuites {
             #expect(refreshCount == 1, "동시 401에도 토큰 갱신은 단 1회여야 한다 (thundering-herd 방지)")
         }
 
+        /// 갱신 Task는 하나로 합쳐지지만 그 실패는 대기하던 요청 전원에게 전달된다.
+        /// 각자 콜백을 부르면 강제 로그아웃 통지가 요청 수만큼 나간다.
+        @Test("동시 401에서 갱신이 실패해도 onRefreshFailed 통지는 1회만 나간다")
+        func notifiesRefreshFailureOnceUnderConcurrent401() async throws {
+            // 지연을 줘서 모든 동시 요청이 먼저 401을 받고 같은 갱신 Task에 합류하도록 한다.
+            let refresh = SpyRefreshService(success: nil, delay: .milliseconds(100))
+            let client = makeClient(refreshService: refresh)
+            StubURLProtocol.handler = { req in (Self.response(req.url, 401), Data("{}".utf8)) }
+
+            let counter = CallCounter()
+            await client.setOnRefreshFailed { Task { await counter.increment() } }
+
+            let req = request(path: "/photos")
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<20 {
+                    group.addTask { _ = try? await client.request(req) }
+                }
+            }
+
+            // 콜백이 Task로 감싸여 있으므로 카운트가 반영될 여지를 준다.
+            try await Task.sleep(for: .milliseconds(100))
+
+            let notifyCount = await counter.value()
+            #expect(notifyCount == 1, "동시 401 20건이 같은 갱신 실패를 공유해도 통지는 1회여야 한다")
+            let refreshCount = await refresh.count()
+            #expect(refreshCount == 1, "갱신 시도 자체도 1회여야 한다")
+        }
+
+        /// 통지를 1회로 접되, 세션이 되살아나면 다음 만료 때 다시 울려야 한다.
+        @Test("갱신에 성공해 세션이 되살아나면 다음 갱신 실패는 다시 통지된다")
+        func notifiesAgainAfterSessionRecovers() async throws {
+            let store = MockTokenStore(accessToken: "old", refreshToken: "r")
+            let refresh = ScriptedRefreshService(results: [
+                TokenPair(accessToken: "new", refreshToken: "r2"), // 1회차: 성공
+                nil                                                // 2회차: 실패
+            ])
+            let client = makeClient(tokenStore: store, refreshService: refresh)
+
+            let counter = CallCounter()
+            await client.setOnRefreshFailed { Task { await counter.increment() } }
+
+            // 1라운드: 401 → 갱신 성공 → 재시도 성공. 통지 없음.
+            StubURLProtocol.handler = { req in
+                let authorized = req.value(forHTTPHeaderField: "Authorization") == "Bearer new"
+                return (Self.response(req.url, authorized ? 200 : 401), Data("{}".utf8))
+            }
+            _ = try await client.request(request(path: "/photos"))
+
+            try await Task.sleep(for: .milliseconds(50))
+            let afterRecovery = await counter.value()
+            #expect(afterRecovery == 0, "갱신이 성공했으면 통지는 없어야 한다")
+
+            // 2라운드: 다시 401 → 이번엔 갱신 실패 → 통지가 나가야 한다.
+            StubURLProtocol.handler = { req in (Self.response(req.url, 401), Data("{}".utf8)) }
+            await #expect(throws: NetworkError.unauthorized) {
+                _ = try await client.request(self.request(path: "/photos"))
+            }
+
+            try await Task.sleep(for: .milliseconds(50))
+            let afterFailure = await counter.value()
+            #expect(afterFailure == 1, "세션이 되살아난 뒤의 갱신 실패는 다시 통지돼야 한다")
+        }
+
         // MARK: - logout
 
         @Test("logout은 저장된 토큰을 삭제하고 로그인 상태를 false로 만든다")
@@ -228,4 +291,33 @@ actor SpyRefreshService: TokenRefreshService {
     }
 
     func count() -> Int { callCount }
+}
+
+
+
+/// 호출마다 다른 결과를 내는 토큰 갱신 서비스. nil이면 실패를 던진다.
+/// 대본을 다 쓰면 마지막 결과를 반복한다.
+actor ScriptedRefreshService: TokenRefreshService {
+    private let results: [TokenPair?]
+    private var index = 0
+
+    init(results: [TokenPair?]) {
+        self.results = results
+    }
+
+    func refresh(_ refreshToken: String) async throws -> TokenPair {
+        let result = results[min(index, results.count - 1)]
+        index += 1
+        guard let result else { throw NetworkError.unauthorized }
+        return result
+    }
+}
+
+/// onRefreshFailed 호출 횟수를 세는 카운터.
+/// 콜백이 @Sendable 클로저라 actor로 감싸 경합 없이 집계한다.
+actor CallCounter {
+    private var count = 0
+
+    func increment() { count += 1 }
+    func value() -> Int { count }
 }

--- a/Rephoto_iOSTests/Support/TestHelpers.swift
+++ b/Rephoto_iOSTests/Support/TestHelpers.swift
@@ -9,6 +9,33 @@ import Foundation
 import Testing
 @testable import Rephoto_iOS
 
+// MARK: - RequestTask 검증 헬퍼
+
+/// APITarget 계약 테스트용 RequestTask 구조 접근자.
+///
+/// RequestTask는 연관값에 `any Encodable`을 담아 Equatable을 만족시킬 수 없으므로,
+/// 케이스 판별과 연관값 추출을 옵셔널 반환으로 감싸 `#require`/`#expect`와 조합해 쓴다.
+extension RequestTask {
+
+    /// 바디가 없는 요청인지 여부
+    var isPlain: Bool {
+        if case .plain = self { return true }
+        return false
+    }
+
+    /// `.jsonEncodable`의 바디를 구체 DTO 타입으로 꺼낸다. 케이스나 타입이 다르면 nil.
+    func jsonBody<T: Encodable>(as type: T.Type) -> T? {
+        guard case .jsonEncodable(let body) = self else { return nil }
+        return body as? T
+    }
+
+    /// `.multipart`의 파트 목록을 꺼낸다. 다른 케이스면 nil.
+    var multipartItems: [MultipartFormItem]? {
+        guard case .multipart(let items) = self else { return nil }
+        return items
+    }
+}
+
 // MARK: - 직렬화 컨테이너
 
 /// StubURLProtocol의 전역 상태(handler/recordedRequests)를 공유하는 스위트들의 컨테이너.

--- a/Rephoto_iOSTests/TESTING.md
+++ b/Rephoto_iOSTests/TESTING.md
@@ -1,0 +1,143 @@
+# 테스트 정책
+
+무엇을 테스트하고 무엇을 의도적으로 빼두었는지, 그리고 그 판단의 근거를 적는다.
+커버리지 공백이 "누락"이 아니라 "판단 결과"임을 남기는 것이 이 문서의 목적이다.
+
+벤치마크의 측정 방법과 수치는 [`TEST_GUIDE.md`](TEST_GUIDE.md) / [`BASELINE_RESULTS.md`](BASELINE_RESULTS.md)에 따로 있다.
+
+---
+
+## 무엇을 테스트하는가
+
+### 네트워크 코어 — `Network/` (30 케이스)
+
+| 스위트 | 검증 대상 |
+|---|---|
+| `NetworkClient` (9) | Bearer 주입 / 공개 경로 제외, 401 후 갱신·재시도, 갱신 실패 시 `onRefreshFailed`, **동시 401 20건에도 갱신 정확히 1회**(thundering-herd 방지) |
+| `NetworkAdapter` (8) | `APITargetType` → `URLRequest` 조립. `.plain` / `.jsonEncodable` / `.multipart` 3경로와 헤더 우선순위 |
+| `KeychainTokenStore` (6) | 저장·조회·덮어쓰기·삭제, service 격리, actor 직렬화 하 동시 접근 |
+| `DefaultAuthenticationPolicy` (4) | 공개/보호 경로 판정. `/relogin` `/joint` 같은 유사 경로가 공개로 새지 않는지 |
+| `PhotoRepository` (3) | 업로드 오케스트레이션 — 빈 입력 단락, 성공 시 S3 N회 + batch 1회, 부분 실패 시 batch 미호출 |
+
+여기가 깨지면 화면 전체가 함께 죽는다. 최우선으로 둔다.
+
+### API 계약 — `Features/*/Data/*APITargetTests.swift` (37 케이스)
+
+`APITarget` 6종(`Photos` / `Tag` / `Description` / `Search` / `Album` / `User`)의
+`path` · `method` · `task` · `headers`를 값으로 고정한다.
+
+서버 스펙이 바뀌어도 컴파일은 통과하고 런타임에서야 깨지는 계층이다.
+순수 함수라 실행 비용이 거의 0(6개 스위트 합계 20ms 미만)이면서 스펙 변경의 1차 방어선이 된다.
+
+특히 값으로 묶어둘 이유가 있는 지점:
+
+- `UserAPITarget` — `getUser` / `updateUser` / `deleteUser`가 `/users` 하나를 공유하고 method로만 갈린다
+- `UserAPITarget` — `/login` `/join` `/auth/refresh`는 `DefaultAuthenticationPolicy`가 공개 경로로 판정하는 값이다. path가 틀어지면 토큰 주입 여부까지 함께 틀어진다
+- `RefreshTokenRequestDTO` — 서버가 바디 키로 `Authorization`을 기대한다. 틀어지면 갱신이 조용히 실패하고 전 화면이 강제 로그아웃된다
+- `PhotosAPITarget.s3Upload` — 유일하게 `headers`를 `nil`로 내려 어댑터가 boundary 포함 Content-Type을 설정하게 위임한다
+
+### Presentation 상태 전이 — `Presentation/` (12 케이스)
+
+| 스위트 | 검증 대상 |
+|---|---|
+| `SessionStoreTests` (8) | 토큰 유무에 따른 자동 로그인 복원, 로그인·로그아웃 상태 전이, 서버 로그아웃 실패해도 로컬 상태는 정리, 리프레시 실패 콜백 → 강제 로그아웃 |
+| `LoginViewModelTests` (4) | 빈 입력 검증 시 세션 미호출, 성공·실패 시 `isLoading` / `errorMessage` 전이 |
+
+### 성능 baseline — `Performance/`
+
+7개 클래스 29개 측정. 회귀 판정 기준은 [`BASELINE_RESULTS.md`](BASELINE_RESULTS.md),
+측정 방법과 스위트 정리 이력은 [`TEST_GUIDE.md`](TEST_GUIDE.md)에 있다.
+(이 중 19개가 baseline 대조 대상이고, `HomeDerivedCollectionPerformanceTests`와
+`UploadMemoryBenchmark`는 A/B 실측·측정 전용이라 카운트에서 제외한다.)
+
+---
+
+## 무엇을 아직 테스트하지 않는가 (의도적 제외)
+
+**SwiftUI View 스냅샷** — 렌더링이 바뀔 때마다 유지비가 발생한다.
+1인 개발 규모에서 ROI가 맞지 않는다고 판단해, ViewModel 레벨 상태 전이 검증으로 대체했다
+(`SessionStoreTests` / `LoginViewModelTests`).
+
+**UseCase 위임 계층** — 대부분 Repository 단순 위임이라 후순위.
+분기 로직이 생기는 시점에 추가한다. 현재 유일한 후보는 `UploadPhotosUseCase`로,
+`TaskGroup` 병렬 업로드와 부분 실패 처리를 담고 있다.
+다만 그 오케스트레이션은 `PhotoRepositoryTests`가 이미 한 겹 덮고 있다.
+
+**Search / Settings 피처의 ViewModel** — `SearchViewModel` / `AlbumViewModel`은
+Home / User 대비 로직 밀도가 낮아 후순위. 두 피처의 `APITarget` 계약은 위에서 덮었다.
+`Settings`는 아직 placeholder다.
+
+**DTO 매핑** — `toDomain()`의 정상 경로는 `PhotoRepositoryTests`와 `DecodingPerformanceTests`가
+간접적으로 지나간다. URL·날짜 파싱 실패 시 `RepositoryError.decodingFailed`로 떨어지는
+경로는 아직 직접 검증하지 않았다.
+
+---
+
+## 프레임워크 선택 기준
+
+기본은 **Swift Testing** (`@Suite` / `@Test` / `#expect`). 새 테스트는 여기에 쓴다.
+
+**XCTest는 두 곳에만 남아 있다.**
+
+1. `Performance/` — Swift Testing에 `measure(metrics:)` 대응 API가 없다. 이관 계획 없음.
+2. `Presentation/` — XCTest로 먼저 작성됐다. 기술적 제약은 없고 이관 대상이지만,
+   동작하는 테스트를 건드릴 이유가 약해 미뤄둔 상태다.
+
+전역 상태(`handler` / `recordedRequests`)를 쓰는 `StubURLProtocol` 기반 스위트는
+`StubURLProtocolSuites` 네임스페이스의 extension으로 선언한다.
+Swift Testing은 스위트 간에도 병렬 실행하므로, `.serialized`를 컨테이너에 걸어
+자식 전체에 재귀 적용시켜 직렬 실행을 보장한다 (`Support/TestHelpers.swift`).
+
+같은 이유로 테스트 플랜의 `parallelizable`은 두 플랜 모두 `false`다.
+
+---
+
+## 실행
+
+| 테스트 플랜 | 대상 | 시점 |
+|---|---|---|
+| `Rephoto_iOS.xctestplan` | 단위 테스트 79케이스 (성능 제외) | PR / push · CI 게이트 |
+| `Rephoto_Performance.xctestplan` | 벤치마크 29케이스만 | 수동 · baseline 대조 |
+
+플랜만 분리하고 **테스트 타겟은 1개**로 유지한다. 단일 앱 타겟이라 어느 쪽이든
+`@testable import Rephoto_iOS`가 동일해서, 타겟을 쪼개도 격리 이득이 없기 때문이다.
+
+성능 벤치마크를 PR 게이트에 넣지 않는 이유는 머신 편차가 신호보다 클 수 있기 때문이다.
+같은 이유로 `XCTMemoryMetric`은 baseline 비교에서 제외했다 (상세: [`TEST_GUIDE.md`](TEST_GUIDE.md)).
+
+로컬 실행:
+
+```bash
+# 단위 (CI와 동일)
+xcodebuild test -project Rephoto_iOS.xcodeproj -scheme Rephoto_iOS \
+  -testPlan Rephoto_iOS \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -enableCodeCoverage YES
+
+# 벤치마크
+xcodebuild test -project Rephoto_iOS.xcodeproj -scheme Rephoto_iOS \
+  -testPlan Rephoto_Performance \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Xcode에서는 `Cmd + U`로 활성 플랜을 실행한다. 플랜 전환은 스킴 에디터 > Test > Test Plans.
+
+### 주의: `CODE_SIGNING_ALLOWED=NO`를 test에 붙이지 말 것
+
+서명을 끄면 엔타이틀먼트가 없어 `KeychainTokenStore` 스위트 5개가
+`errSecMissingEntitlement`(`-34018`)로 실패한다.
+시뮬레이터는 ad-hoc 서명으로 충분하므로 CI의 `Test` 스텝에서는 이 플래그를 쓰지 않는다.
+(`Build` 스텝에는 남겨둬도 무방하다.)
+
+---
+
+## 커버리지
+
+CI가 `-enableCodeCoverage YES`로 실행하고, `xccov` 리포트를 Actions 요약에 출력한다.
+
+```bash
+xcrun xccov view --report --only-targets TestResults.xcresult
+```
+
+커버리지는 목표 수치를 정해두지 않았다. 위의 "무엇을 테스트하는가"에 적힌
+우선순위대로 덮였는지를 보는 참고 지표로만 쓴다.

--- a/Rephoto_iOSTests/TESTING.md
+++ b/Rephoto_iOSTests/TESTING.md
@@ -108,10 +108,11 @@ Swift Testing은 스위트 간에도 병렬 실행하므로, `.serialized`를 �
 로컬 실행:
 
 ```bash
-# 단위 (CI와 동일)
+# 단위 (CI와 동일). 아래 커버리지 명령이 읽을 결과 번들도 함께 남긴다.
 xcodebuild test -project Rephoto_iOS.xcodeproj -scheme Rephoto_iOS \
   -testPlan Rephoto_iOS \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -resultBundlePath TestResults.xcresult \
   -enableCodeCoverage YES
 
 # 벤치마크


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용

Close #55

### 1. CI에서 단위 테스트 실행 + 커버리지 측정 (`6bd6320`)

빌드만 검증하고 있어서 테스트 71개가 CI에서 한 번도 실행되지 않았습니다.
`Build` 스텝 뒤에 `xcodebuild test`와 `xccov` 요약 출력을 붙여 PR 게이트로 만들었습니다.

- 테스트 실행 시간만큼 `timeout-minutes` 20 → 30
- 커버리지 리포트는 `always()`로 실행해 테스트 실패 시에도 수치를 남깁니다
- `TestResults.xcresult` gitignore

### 2. 테스트 플랜을 단위/성능 2개로 분리 (`19bc257`)

성능 벤치마크는 머신 편차가 신호보다 클 수 있어 PR 게이트에 부적합합니다.
그렇다고 빼면 baseline 대조 수단이 사라지므로, **타겟은 1개로 두고 실행 대상만** 나눴습니다.

| 플랜 | 대상 | 시점 |
|---|---|---|
| `Rephoto_iOS.xctestplan` | 단위 79케이스 (`skippedTests`로 성능 제외) | PR / push · CI 게이트 |
| `Rephoto_Performance.xctestplan` | 벤치마크 29케이스 (`selectedTests`) | 수동 · baseline 대조 |

`parallelizable`은 두 플랜 모두 `false` 유지 — `StubURLProtocol`이 전역 상태를 씁니다.

### 3. APITarget 6종 계약 테스트 추가 (`dfa7de4`)

`APITarget` 계층이 전부 무테스트였습니다. 서버 스펙(`path`/`method`/`task`/`headers`)이
바뀌어도 컴파일은 통과하고 런타임에서야 깨집니다. 순수 함수라 실행 비용이 거의 0(6개 스위트 합계 20ms 미만)이면서
스펙 변경의 1차 방어선이 됩니다.

Photos / Tag / Description / Search / Album / User 6종, 37 케이스. Swift Testing 기반.

### 4. 401 재시도 한도 초과 시 `onRefreshFailed` 중복 호출 수정 (`56da39e`)

**CI에 테스트를 붙이자마자 드러난 기존 실패입니다.** 상세는 아래 리뷰 포인트에 적었습니다.

### 5. 테스트 정책 문서 + README CI 섹션 (`971c01b`)

`Rephoto_iOSTests/TESTING.md` 신규. 커버리지 공백이 "누락"이 아니라 "판단 결과"임을 남깁니다.

## 📋 추후 진행 상황

- `Presentation/` 스위트 2개(`LoginViewModelTests`, `SessionStoreTests`) XCTest → Swift Testing 이관
- `UploadPhotosUseCase` 단위 테스트 (분기 로직이 있는 유일한 UseCase)
- DTO `toDomain()` 실패 경로(`RepositoryError.decodingFailed`) 검증

## 📌 리뷰 포인트

### `NetworkClient` 버그 (커밋 4)

`performRequest`에서 재귀 재시도 호출이 `do` 블록 **안**에 있었습니다.

| 단계 | 동작 |
|---|---|
| `retryCount: 0` | 401 → 갱신 성공 → `performRequest(retryCount: 1)` 호출 |
| `retryCount: 1` | 401 → `1 < 1` 실패 → `onRefreshFailed?()` **1회차** → throw |
| 되돌아온 throw | 재귀 호출이 `do` 안이라 `catch is NetworkError`에 걸림 → `onRefreshFailed?()` **2회차** |

`catch`는 `refreshToken()` 실패만 잡으려던 의도인데 재귀 호출의 throw까지 잡습니다.
재귀가 풀리며 각 깊이에서 한 번씩 더 잡히므로 총 `maxRetryCount + 1`회 호출됩니다.

재시도 호출을 `do` 밖으로 옮겨 해결했습니다.

**사용자 영향은 없었습니다.** 현재 핸들러인 `SessionStore.forceLogout()`이 멱등해서(로컬 상태만 정리)
증상이 나타나지 않았습니다. 다만 콜백에 서버 로그아웃 호출·알럿·분석 이벤트 같은
부수효과가 붙는 순간 바로 문제가 되는 구조라 고쳤습니다.

### Test 스텝에 `CODE_SIGNING_ALLOWED=NO`를 붙이지 않은 이유

서명을 끄면 엔타이틀먼트가 없어 `KeychainTokenStore` 스위트 5개가
`errSecMissingEntitlement`(`-34018`)로 실패합니다. 시뮬레이터는 ad-hoc 서명으로 충분합니다.
`Build` 스텝에는 그대로 뒀습니다.

### `project.pbxproj` 미수정

테스트 타겟이 `PBXFileSystemSynchronizedRootGroup`이라 새 `.swift` 파일이 자동으로 타겟에 편입됩니다
(빌드 로그로 확인). `Rephoto_Performance.xctestplan`도 스킴이 `container:` 경로로 참조하므로
동작에는 지장이 없으나, Xcode 네비게이터에는 안 보일 수 있습니다.

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?

### 로컬 검증 결과

- 단위 플랜: **79개 전부 통과**, `Performance/` 7개 클래스 실행 0건
- 성능 플랜: 벤치마크 7개 클래스 29개만 실행, 단위 스위트 미실행
- `xcrun xccov view --report --only-targets` 정상 출력 (`Rephoto_iOS.app` 32.12%, 1523/4742)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 인증 토큰 갱신 후 재시도 과정에서 오류 콜백이 중복 호출되는 문제를 수정했습니다.

- **테스트 및 품질**
  - API 요청 계약 검증 테스트를 추가했습니다.
  - CI에서 단위 테스트와 성능 테스트를 실행하고 코드 커버리지 요약을 제공합니다.
  - 성능 및 메모리 벤치마크 테스트 플랜을 정비했습니다.

- **문서**
  - 테스트 범위, 실행 방법, 커버리지 보고 정책을 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->