### PR TITLE
[Refactor] SwiftUI 관찰 의존성 누수 2건 해소

### DIFF
--- a/Rephoto_iOS/Features/Home/Presentation/ViewModels/HomeViewModel.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/ViewModels/HomeViewModel.swift
@@ -24,11 +24,16 @@ final class HomeViewModel {
             visiblePhotos = photos.filter { !$0.isSensitive }
             sensitivePhotos = photos.filter(\.isSensitive)
             sensitiveCount = sensitivePhotos.count
+            hasPhotos = !photos.isEmpty
         }
     }
     private(set) var visiblePhotos: [Photo] = []
     private(set) var sensitivePhotos: [Photo] = []
     private(set) var sensitiveCount: Int = 0
+    /// `isShowingErrorAlert`가 `photos`를 직접 읽지 않도록 캐싱한다.
+    /// 계산 프로퍼티에서 `photos`를 읽으면 관찰 의존성이 배열 전체로 전이되어,
+    /// 파생 컬렉션을 캐싱해 좁혀둔 무효화 범위가 알림 경로를 통해 다시 넓어진다.
+    private(set) var hasPhotos: Bool = false
     private(set) var isLoading: Bool = false
     private(set) var errorMessage: String?
     private(set) var uploadProgress: UploadProgress?
@@ -36,7 +41,7 @@ final class HomeViewModel {
     // 사진이 있는 상태의 실패(업로드 등)만 알림으로 표시 — 빈 화면 에러는 전체 화면 상태가 담당.
     // KeyPath 기반 Binding($vm.isShowingErrorAlert)으로 쓰기 위한 양방향 프로퍼티
     var isShowingErrorAlert: Bool {
-        get { errorMessage != nil && !photos.isEmpty }
+        get { errorMessage != nil && hasPhotos }
         set { if !newValue { errorMessage = nil } }
     }
 

--- a/Rephoto_iOS/Features/Home/Presentation/Views/SensitivePhotosView.swift
+++ b/Rephoto_iOS/Features/Home/Presentation/Views/SensitivePhotosView.swift
@@ -16,6 +16,9 @@ struct SensitivePhotosView: View {
     let namespace: Namespace.ID
 
     @State private var isUnlocked = false
+    // 알림 표시 여부를 별도 @State로 둬야 클로저 없이 KeyPath 바인딩($isShowingAuthAlert)을 쓸 수 있다.
+    // 두 값은 presentAuthError(_:)에서만 함께 갱신한다.
+    @State private var isShowingAuthAlert = false
     @State private var authErrorMessage: String?
     @Environment(\.scenePhase) private var scenePhase
 
@@ -54,18 +57,16 @@ struct SensitivePhotosView: View {
                 isUnlocked = false
             }
         }
-        .alert("잠금 해제 실패", isPresented: authAlertBinding) {
+        .alert("잠금 해제 실패", isPresented: $isShowingAuthAlert, presenting: authErrorMessage) { _ in
             Button("확인", role: .cancel) {}
-        } message: {
-            Text(authErrorMessage ?? "")
+        } message: { message in
+            Text(message)
         }
     }
 
-    private var authAlertBinding: Binding<Bool> {
-        Binding(
-            get: { authErrorMessage != nil },
-            set: { if !$0 { authErrorMessage = nil } }
-        )
+    private func presentAuthError(_ message: String) {
+        authErrorMessage = message
+        isShowingAuthAlert = true
     }
 
     private func authenticate() async {
@@ -78,7 +79,7 @@ struct SensitivePhotosView: View {
             // Face ID 테스트: Simulator 메뉴 Features > Face ID > Enrolled 후 Matching Face
             withAnimation { isUnlocked = true }
             #else
-            authErrorMessage = error?.localizedDescription ?? "이 기기에서는 인증을 사용할 수 없어요"
+            presentAuthError(error?.localizedDescription ?? "이 기기에서는 인증을 사용할 수 없어요")
             #endif
             return
         }
@@ -95,7 +96,7 @@ struct SensitivePhotosView: View {
         } catch let laError as LAError where laError.code == .userCancel || laError.code == .appCancel || laError.code == .systemCancel {
             // 사용자/시스템 취소는 에러로 표시하지 않음
         } catch {
-            authErrorMessage = error.localizedDescription
+            presentAuthError(error.localizedDescription)
         }
     }
 }


### PR DESCRIPTION
Closes #57

## ✨ PR 유형

- [x] 코드 리팩토링

## 🛠️ 작업내용

Apple의 SwiftUI 데이터 플로우 가이드와 대조해 발견한 두 지점을 고친다. 동작 변화는 없다.

### 1. `isShowingErrorAlert`가 `photos` 전체에 의존성을 걸고 있었다

```swift
// before
var isShowingErrorAlert: Bool {
    get { errorMessage != nil && !photos.isEmpty }   // ← photos 전체를 읽음
}
```

계산 프로퍼티의 관찰 의존성은 **전이**된다. `HomeView`가 `.alert(isPresented: $vm.isShowingErrorAlert)`로 이 값을 읽으므로, HomeView의 body가 `photos` 배열 전체에 의존하게 된다. **#47에서 파생 컬렉션을 didSet으로 캐싱해 좁혀둔 무효화 범위가 알림 경로를 통해 다시 넓어지고 있었다.**

`hasPhotos`를 같은 didSet에서 캐싱하고 게터가 이를 읽도록 바꿨다.

### 2. `authAlertBinding`이 클로저 바인딩이었다

```swift
// before
private var authAlertBinding: Binding<Bool> {
    Binding(get: { authErrorMessage != nil },
            set: { if !$0 { authErrorMessage = nil } })
}
```

`Binding(get:set:)`은 body 실행마다 힙 할당이 생기고 비교가 깨져 불필요한 무효화를 유발한다. `isShowingAuthAlert`를 `@State`로 분리해 KeyPath 바인딩으로 전환하고, 메시지는 `alert(_:isPresented:presenting:)`으로 전달한다. 두 상태가 어긋나지 않도록 갱신은 `presentAuthError(_:)` 한 곳으로 모았다.

`HomeViewModel`은 KeyPath 바인딩을 쓰려고 일부러 양방향 프로퍼티를 만들어뒀는데 여기만 반대로 되어 있어, 일관성도 함께 맞췄다.

## 📋 추후 진행 상황

- Search / User 피처의 동일 패턴 점검은 아직 하지 않았다

## 📌 리뷰 포인트

- 근거: Apple `dataflow.md` — *"Computed properties still establish dependencies transitively... The fix is to cache the derived value as its own stored property"*, *"Creating a closure means a new heap allocation each time body is run"*
- `Photo`가 `Hashable`이라 `[Photo]`도 Equatable이다. `@Observable` 매크로가 생성한 setter가 동일 값 재대입 시 무효화를 건너뛰므로, didSet 캐싱의 이점이 실제로 발생하는 전제가 갖춰져 있다
- 벤치마크(#58)는 읽기 CPU 비용만 측정하고 이 무효화 범위는 측정하지 않는다 — 이 PR의 효과는 벤치마크 수치로 나타나지 않는다

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?