### PR TITLE
[Fix] 앨범에서 사진 선택 시 상세 위로 앨범이 다시 덮이는 문제

### DIFF
--- a/Rephoto_iOS/Features/Search/Domain/Models/Album.swift
+++ b/Rephoto_iOS/Features/Search/Domain/Models/Album.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-struct Album: Identifiable, Sendable {
+// Hashable — NavigationLink(value:) / navigationDestination(for:)의 값 기반 라우팅에 쓰인다
+struct Album: Identifiable, Hashable, Sendable {
     let tagId: Int
     let tagName: String
     var id: Int { tagId }

--- a/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
+++ b/Rephoto_iOS/Features/Search/Presentation/Views/SearchView.swift
@@ -41,6 +41,10 @@ struct SearchView: View {
                     guard !Task.isCancelled else { return }
                     await searchVM.search(query: trimmedQuery)
                 }
+                // destination은 lazy 컨테이너 밖, 스택 루트에 등록한다
+                .navigationDestination(for: Album.self) { album in
+                    AlbumDetailView(album: album, provider: albumVM.provider, namespace: photoZoom)
+                }
                 .navigationDestination(for: Photo.self) { photo in
                     PhotoInfoView(photo: photo, provider: homeProvider)
                         // 홈과 동일하게 타일에서 사진이 확대되어 나오는 줌 전환
@@ -79,9 +83,7 @@ struct SearchView: View {
             } else {
                 AlbumGridSection(
                     albums: albumVM.albums,
-                    previews: albumVM.albumPreviews,
-                    provider: albumVM.provider,
-                    namespace: photoZoom
+                    previews: albumVM.albumPreviews
                 )
             }
         } else if searchVM.searchResults.isEmpty {
@@ -106,8 +108,6 @@ struct SearchView: View {
 private struct AlbumGridSection: View {
     let albums: [Album]
     let previews: [Int: AlbumViewModel.AlbumPreview]
-    let provider: SearchUseCaseProviderProtocol
-    let namespace: Namespace.ID
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 2)
 
@@ -125,9 +125,9 @@ private struct AlbumGridSection: View {
 
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(albums) { album in
-                    NavigationLink {
-                        AlbumDetailView(album: album, provider: provider, namespace: namespace)
-                    } label: {
+                    // 값 기반 링크로 통일 — 뷰를 직접 넘기는 링크와 섞으면, 앨범 안에서
+                    // 사진(value)을 push할 때 SwiftUI가 앨범(view)을 pop했다가 다시 덮는다
+                    NavigationLink(value: album) {
                         AlbumCard(album: album, preview: previews[album.tagId])
                     }
                     .buttonStyle(.plain)


### PR DESCRIPTION
Closes #60

## ✨ PR 유형

- [x] 버그 수정

## 🛠️ 작업내용

`SearchView`가 한 `NavigationStack` 안에서 두 종류의 `NavigationLink`를 섞어 쓰고 있었다.

- 앨범 — view-destination: `NavigationLink { AlbumDetailView(...) }`
- 사진 — value-destination: `NavigationLink(value:)` + `navigationDestination(for: Photo.self)`

Apple 문서(*Understanding the navigation stack*)에 명시된 동작이다:

> If you attempt to push a value while a view-destination link is on the stack, SwiftUI pops all view destinations and pushes the value’s destination onto the stack.

앨범 안에서 사진을 누르면 앨범이 pop되며 `PhotoInfoView`가 뜨고, 루트가 재평가되며 view-destination 링크가 다시 활성화되어 그 위를 앨범이 덮었다.

앨범 링크도 값 기반으로 통일했다.

- `Album`에 `Hashable` 추가
- `NavigationLink(value: album)`으로 교체
- `navigationDestination(for: Album.self)`를 스택 루트에 등록 — lazy 컨테이너 밖이어야 스택이 항상 destination을 볼 수 있다

## 📋 추후 진행 상황

Search / User 피처의 나머지 데이터플로우 점검은 아직 하지 않았다. 이번 건은 네비게이션 경로만 다뤘다.

## 📌 리뷰 포인트

- `AlbumGridSection`이 더는 읽지 않는 `provider` / `namespace` 입력을 제거했다. 읽지 않는 입력을 들고 있으면 무효화 범위만 넓어진다
- `HomeView`는 원래 전부 값 기반(`Photo`, `SensitivePhotosRoute`)이라 영향 없다
- 앨범 → 사진 → 뒤로 동선을 시뮬레이터에서 한 번 확인해주시면 좋겠다

## ✅ Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?